### PR TITLE
Make WorkersRegistry constructor attributes private with dependency injection

### DIFF
--- a/source/lib/registry/WorkersRegistry.js
+++ b/source/lib/registry/WorkersRegistry.js
@@ -6,18 +6,33 @@ import { IdentifyableCollection } from '../utils/IdentifyableCollection.js';
  * @author darthjee
  */
 class WorkersRegistry {
+  #jobRegistry;
+  #quantity;
+  #workers;
+  #busy;
+  #idle;
+
   /**
    * Creates a new WorkersRegistry instance.
    * @param {object} params - The parameters for creating a WorkersRegistry instance.
    * @param {JobRegistry} params.jobRegistry - The job registry shared among all workers.
    * @param {number} params.quantity - The number of workers to be built.
+   * @param {IdentifyableCollection} [params.workers] - The collection of all workers (injected for testing).
+   * @param {IdentifyableCollection} [params.busy] - The collection of busy workers (injected for testing).
+   * @param {IdentifyableCollection} [params.idle] - The collection of idle workers (injected for testing).
    */
-  constructor({ jobRegistry, quantity }) {
-    this.jobRegistry = jobRegistry;
-    this.quantity = quantity;
-    this.workers = new IdentifyableCollection();
-    this.busy = new IdentifyableCollection();
-    this.idle = new IdentifyableCollection();
+  constructor({
+    jobRegistry,
+    quantity,
+    workers = new IdentifyableCollection(),
+    busy = new IdentifyableCollection(),
+    idle = new IdentifyableCollection()
+  }) {
+    this.#jobRegistry = jobRegistry;
+    this.#quantity = quantity;
+    this.#workers = workers;
+    this.#busy = busy;
+    this.#idle = idle;
   }
 
   /**
@@ -28,7 +43,7 @@ class WorkersRegistry {
    * @returns {void}
    */
   initWorkers() {
-    for (let i = 0; i < this.quantity; i++) {
+    for (let i = 0; i < this.#quantity; i++) {
       this.#buildWorker();
     }
   }
@@ -38,11 +53,11 @@ class WorkersRegistry {
    * @param {string} worker_id - The ID of the worker to set as busy.
    */
   setBusy(worker_id) {
-    const worker = this.workers.get(worker_id);
+    const worker = this.#workers.get(worker_id);
 
     if (worker) {
-      this.idle.remove(worker_id);
-      this.busy.push(worker);
+      this.#idle.remove(worker_id);
+      this.#busy.push(worker);
     }
   }
 
@@ -51,11 +66,11 @@ class WorkersRegistry {
    * @param {string} worker_id - The ID of the worker to set as idle.
    */
   setIdle(worker_id) {
-    const worker = this.workers.get(worker_id);
+    const worker = this.#workers.get(worker_id);
 
     if (worker) {
-      this.busy.remove(worker_id);
-      this.idle.push(worker);
+      this.#busy.remove(worker_id);
+      this.#idle.push(worker);
     }
   }
 
@@ -64,7 +79,7 @@ class WorkersRegistry {
    * @returns {boolean} True if there is at least one busy worker, false otherwise.
    */
   hasBusyWorker() {
-    return this.busy.hasAny();
+    return this.#busy.hasAny();
   }
 
   /**
@@ -72,7 +87,7 @@ class WorkersRegistry {
    * @returns {boolean} True if there is at least one idle worker, false otherwise.
    */
   hasIdleWorker() {
-    return this.idle.hasAny();
+    return this.#idle.hasAny();
   }
 
   /**
@@ -83,11 +98,11 @@ class WorkersRegistry {
     if (!this.hasIdleWorker()) {
       return null;
     }
-    const workerId = this.idle.byIndex(0).id;
+    const workerId = this.#idle.byIndex(0).id;
 
     this.setBusy(workerId);
 
-    return this.workers.get(workerId);
+    return this.#workers.get(workerId);
   }
 
   /**
@@ -96,10 +111,10 @@ class WorkersRegistry {
    */
   #buildWorker() {
     const id = this.#generateUUID();
-    const worker = new Worker({ id, jobRegistry: this.jobRegistry, workerRegistry: this });
+    const worker = new Worker({ id, jobRegistry: this.#jobRegistry, workerRegistry: this });
 
-    this.workers.push(worker);
-    this.idle.push(worker);
+    this.#workers.push(worker);
+    this.#idle.push(worker);
 
     return worker;
   }
@@ -109,7 +124,7 @@ class WorkersRegistry {
    * @returns {string} A unique UUID string.
    */
   #generateUUID() {
-    return this.workers.generateUUID();
+    return this.#workers.generateUUID();
   }
 }
 

--- a/source/lib/services/Application.js
+++ b/source/lib/services/Application.js
@@ -4,6 +4,17 @@ import { JobRegistry } from '../registry/JobRegistry.js';
 import { WorkersRegistry } from '../registry/WorkersRegistry.js';
 
 class Application {
+  #workers;
+
+  /**
+   * Creates a new Application instance.
+   * @param {object} [params={}] - Optional parameters for dependency injection.
+   * @param {IdentifyableCollection} [params.workers] - Workers collection (injected for testing).
+   */
+  constructor({ workers } = {}) {
+    this.#workers = workers;
+  }
+
   /**
    * Loads the configuration from the specified file path.
    * @param {string} configPath - The path to the configuration file.
@@ -20,7 +31,9 @@ class Application {
     this.config = Config.fromFile(configPath);
     this.jobRegistry = new JobRegistry();
     this.workersRegistry = new WorkersRegistry({
-      jobRegistry: this.jobRegistry, ...this.config.workersConfig
+      jobRegistry: this.jobRegistry,
+      ...this.config.workersConfig,
+      workers: this.#workers
     });
 
     this.workersRegistry.initWorkers();

--- a/source/spec/registry/WorkersRegistry_spec.js
+++ b/source/spec/registry/WorkersRegistry_spec.js
@@ -13,139 +13,167 @@ describe('WorkersRegistry', () => {
   });
 
   describe('#constructor', () => {
+    let workers;
+
     beforeEach(() => {
-      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 3 });
-    });
-
-    it('stores the job registry', () => {
-      expect(workerRegistry.jobRegistry).toEqual(jobRegistry);
-    });
-
-    it('stores the workers quantity', () => {
-      expect(workerRegistry.quantity).toEqual(3);
+      workers = new IdentifyableCollection();
+      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 3, workers });
     });
 
     it('initializes an empty workers list', () => {
-      expect(workerRegistry.workers).toEqual(new IdentifyableCollection());
+      expect(workers).toEqual(new IdentifyableCollection());
+    });
+
+    it('uses the job registry for created workers', () => {
+      workerRegistry.initWorkers();
+
+      expect(workers.byIndex(0).jobRegistry).toEqual(jobRegistry);
+    });
+
+    it('initializes with the specified quantity', () => {
+      workerRegistry.initWorkers();
+
+      expect(workers.size()).toEqual(3);
     });
   });
 
   describe('#initWorkers', () => {
+    let workers;
+    let busy;
+    let idle;
+
     beforeEach(() => {
-      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 3 });
+      workers = new IdentifyableCollection();
+      busy = new IdentifyableCollection();
+      idle = new IdentifyableCollection();
+      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 3, workers, busy, idle });
     });
 
     it('builds the specified number of workers', () => {
       workerRegistry.initWorkers();
 
-      expect(workerRegistry.workers.size()).toEqual(3);
+      expect(workers.size()).toEqual(3);
     });
 
     it('assigns the job registry to the worker', () => {
       workerRegistry.initWorkers();
 
-      const worker = workerRegistry.workers.byIndex(0);
+      const createdWorker = workers.byIndex(0);
 
-      expect(worker.jobRegistry).toEqual(jobRegistry);
+      expect(createdWorker.jobRegistry).toEqual(jobRegistry);
     });
 
     it('creates the workers as idle', () => {
       workerRegistry.initWorkers();
 
-      const workers = workerRegistry.workers;
-      const idleWorkers = workerRegistry.idle;
-
-      expect(idleWorkers).toEqual(workers);
+      expect(idle).toEqual(workers);
     });
 
     it('does not creates the workers as busy', () => {
       workerRegistry.initWorkers();
 
-      expect(workerRegistry.busy).toEqual(new IdentifyableCollection());
+      expect(busy).toEqual(new IdentifyableCollection());
     });
 
     it('assigns a uuid id to the worker', () => {
       workerRegistry.initWorkers();
 
-      const workers = workerRegistry.workers.list();
-      const worker = workers[0];
+      const createdWorkers = workers.list();
+      const createdWorker = createdWorkers[0];
 
-      expect(worker.id).toMatch(
+      expect(createdWorker.id).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
       );
     });
   });
 
   describe('WorkersRegistry#setBusy', () => {
+    let workers;
+    let busy;
+    let idle;
+
     beforeEach(() => {
-      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1 });
+      workers = new IdentifyableCollection();
+      busy = new IdentifyableCollection();
+      idle = new IdentifyableCollection();
+      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1, workers, busy, idle });
       workerRegistry.initWorkers();
-      worker = workerRegistry.workers.byIndex(0);
+      worker = workers.byIndex(0);
       worker_id = worker.id;
     });
 
     it('moves a worker from idle to busy when the worker exists', () => {
-      expect(workerRegistry.idle.get(worker_id)).toBe(worker);
+      expect(idle.get(worker_id)).toBe(worker);
 
       workerRegistry.setBusy(worker_id);
 
-      expect(workerRegistry.busy.get(worker_id)).toBe(worker);
-      expect(workerRegistry.idle.get(worker_id)).toBeUndefined();
+      expect(busy.get(worker_id)).toBe(worker);
+      expect(idle.get(worker_id)).toBeUndefined();
     });
 
     it('does nothing when the worker id does not exist', () => {
       workerRegistry.setBusy('non-existent-id');
 
-      expect(workerRegistry.busy.size()).toBe(0);
+      expect(busy.size()).toBe(0);
     });
 
     it('is idempotent when called multiple times for the same worker', () => {
       workerRegistry.setBusy(worker_id);
       workerRegistry.setBusy(worker_id);
 
-      expect(workerRegistry.busy.get(worker_id)).toBe(worker);
-      expect(workerRegistry.idle[worker_id]).toBeUndefined();
+      expect(busy.get(worker_id)).toBe(worker);
+      expect(idle[worker_id]).toBeUndefined();
     });
   });
 
   describe('WorkersRegistry#setIdle', () => {
+    let workers;
+    let busy;
+    let idle;
+
     beforeEach(() => {
-      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1 });
+      workers = new IdentifyableCollection();
+      busy = new IdentifyableCollection();
+      idle = new IdentifyableCollection();
+      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1, workers, busy, idle });
       workerRegistry.initWorkers();
-      worker = workerRegistry.workers.byIndex(0);
+      worker = workers.byIndex(0);
       worker_id = worker.id;
       workerRegistry.setBusy(worker_id);
     });
 
     it('moves a worker from busy to idle when the worker exists', () => {
-      expect(workerRegistry.busy.get(worker_id)).toBe(worker);
+      expect(busy.get(worker_id)).toBe(worker);
 
       workerRegistry.setIdle(worker_id);
 
-      expect(workerRegistry.idle.get(worker_id)).toBe(worker);
-      expect(workerRegistry.busy.get(worker_id)).toBeUndefined();
+      expect(idle.get(worker_id)).toBe(worker);
+      expect(busy.get(worker_id)).toBeUndefined();
     });
 
     it('does nothing when the worker id does not exist', () => {
       workerRegistry.setIdle('non-existent-id');
 
-      expect(workerRegistry.idle.size()).toBe(0);
+      expect(idle.size()).toBe(0);
     });
 
     it('is idempotent when called multiple times for the same worker', () => {
       workerRegistry.setIdle(worker_id);
       workerRegistry.setIdle(worker_id);
 
-      expect(workerRegistry.idle.get(worker_id)).toBe(worker);
-      expect(workerRegistry.busy.get(worker_id)).toBeUndefined();
+      expect(idle.get(worker_id)).toBe(worker);
+      expect(busy.get(worker_id)).toBeUndefined();
     });
   });
 
   describe('#hasBusyWorker', () => {
+    let workers;
+
     beforeEach(() => {
-      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1 });
+      workers = new IdentifyableCollection();
+      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1, workers });
       workerRegistry.initWorkers();
-      worker = workerRegistry.workers.byIndex(0);
+      worker = workers.byIndex(0);
       worker_id = worker.id;
     });
 
@@ -160,10 +188,13 @@ describe('WorkersRegistry', () => {
     });
   });
   describe('#hasIdleWorker', () => {
+    let workers;
+
     beforeEach(() => {
-      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1 });
+      workers = new IdentifyableCollection();
+      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1, workers });
       workerRegistry.initWorkers();
-      worker_id = workerRegistry.workers.byIndex(0).id;
+      worker_id = workers.byIndex(0).id;
     });
 
     it('returns true when there is a idle worker', () => {
@@ -177,24 +208,27 @@ describe('WorkersRegistry', () => {
   });
 
   describe('#getIdleWorker', () => {
+    let workers;
+
     beforeEach(() => {
-      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1 });
+      workers = new IdentifyableCollection();
+      workerRegistry = new WorkersRegistry({ jobRegistry, quantity: 1, workers });
       workerRegistry.initWorkers();
-      worker_id = workerRegistry.workers.byIndex(0).id;
+      worker_id = workers.byIndex(0).id;
     });
 
     it('returns an idle worker when available', () => {
-      const worker = workerRegistry.getIdleWorker();
+      const idleWorker = workerRegistry.getIdleWorker();
 
-      expect(worker).toBeDefined();
-      expect(worker.id).toBe(worker_id);
+      expect(idleWorker).toBeDefined();
+      expect(idleWorker.id).toBe(worker_id);
     });
 
     it('returns null when no idle workers are available', () => {
       workerRegistry.setBusy(worker_id);
-      const worker = workerRegistry.getIdleWorker();
+      const idleWorker = workerRegistry.getIdleWorker();
 
-      expect(worker).toBeNull();
+      expect(idleWorker).toBeNull();
     });
   });
 });

--- a/source/spec/services/Application_spec.js
+++ b/source/spec/services/Application_spec.js
@@ -36,13 +36,16 @@ describe('Application', () => {
       });
 
       it('initializes workers registry', () => {
+        const workers = new IdentifyableCollection();
+
+        app = new Application({ workers });
+
         expect(app.workersRegistry).toBeUndefined();
 
         app.loadConfig(configFilePath);
 
         expect(app.workersRegistry instanceof WorkersRegistry).toBeTrue();
-        expect(app.workersRegistry.workers.size()).toEqual(5);
-        expect(app.workersRegistry.busy).toEqual(new IdentifyableCollection());
+        expect(workers.size()).toEqual(5);
       });
     });
 

--- a/source/spec/services/WorkersAllocator_spec.js
+++ b/source/spec/services/WorkersAllocator_spec.js
@@ -2,6 +2,7 @@ import { Job } from '../../lib/models/Job.js';
 import { JobRegistry } from '../../lib/registry/JobRegistry.js';
 import { WorkersRegistry } from '../../lib/registry/WorkersRegistry.js';
 import { WorkersAllocator } from '../../lib/services/WorkersAllocator.js';
+import { IdentifyableCollection } from '../../lib/utils/IdentifyableCollection.js';
 
 describe('WorkersAllocator', () => {
   let jobRegistry;
@@ -9,12 +10,14 @@ describe('WorkersAllocator', () => {
   let allocator;
   let job;
   let worker;
+  let workers;
 
   beforeEach(() => {
     jobRegistry = new JobRegistry();
-    workersRegistry = new WorkersRegistry({ jobRegistry, quantity: 1 });
+    workers = new IdentifyableCollection();
+    workersRegistry = new WorkersRegistry({ jobRegistry, quantity: 1, workers });
     workersRegistry.initWorkers();
-    worker = workersRegistry.workers.byIndex(0);
+    worker = workers.byIndex(0);
     job = new Job({ payload: { value: 1 } });
 
     allocator = new WorkersAllocator({ jobRegistry, workersRegistry });
@@ -71,9 +74,10 @@ describe('WorkersAllocator', () => {
 
   describe('when there when there are several workers', () => {
     beforeEach(() => {
-      workersRegistry = new WorkersRegistry({ jobRegistry, quantity: 3 });
+      workers = new IdentifyableCollection();
+      workersRegistry = new WorkersRegistry({ jobRegistry, quantity: 3, workers });
       workersRegistry.initWorkers();
-      worker = workersRegistry.workers.byIndex(0);
+      worker = workers.byIndex(0);
       allocator = new WorkersAllocator({ jobRegistry, workersRegistry });
 
       jobRegistry.push(job);


### PR DESCRIPTION
`WorkersRegistry` exposed all constructor-initialized attributes as public fields. This refactor makes them private (`#`) and introduces dependency injection for the collection attributes so tests can still observe internal state without direct access.

## WorkersRegistry

- All constructor attributes made private: `#jobRegistry`, `#quantity`, `#workers`, `#busy`, `#idle`
- Constructor accepts optional `workers`, `busy`, `idle` parameters (default to `new IdentifyableCollection()`) enabling injection at test time

```js
// Production — zero change in behaviour
new WorkersRegistry({ jobRegistry, quantity: 5 });

// Tests — inject collections to observe state
const workers = new IdentifyableCollection();
const registry = new WorkersRegistry({ jobRegistry, quantity: 3, workers });
registry.initWorkers();
expect(workers.size()).toEqual(3); // state verified via injected reference
```

## Application

- Added constructor accepting optional `{ workers }` — stored as a private field and forwarded to `WorkersRegistry` inside `loadConfig()`
- Default `{}` argument keeps existing call sites (`new Application()`) unaffected

## Test updates

- `WorkersRegistry_spec` — each `beforeEach` injects collections; assertions reference the injected variables directly instead of private fields
- `WorkersAllocator_spec` — injects `workers` collection; replaces `workersRegistry.workers.byIndex(0)` with `workers.byIndex(0)`
- `Application_spec` — constructs `Application` with an injected `workers` collection and verifies its size after `loadConfig()`
