### PR TITLE
docs: improve README with development, config, and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Navi is a queue-based cache-warmer written in Node.js and distributed as a Docke
 It reads a YAML configuration file, enqueues HTTP requests as jobs, and processes them concurrently using a configurable pool of workers.
 
 Key features:
+
 - Concurrent HTTP request execution via a worker pool.
 - URL templates with placeholder parameters (e.g. `{:id}`).
 - Resource chaining: downstream jobs are enqueued automatically based on the response of a parent request.
@@ -147,6 +148,7 @@ make setup
 ```
 
 This command:
+
 1. Copies `.env.sample` to `.env`.
 2. Builds the `base_build` Docker image.
 3. Installs Node.js dependencies inside the container via `yarn install`.


### PR DESCRIPTION
The README contained only badges and a version stub — no usage, setup, or contribution guidance.

## Changes

- **Overview** — brief description of Navi's queue-based architecture, worker pool, URL templates, resource chaining, and retry behaviour
- **Configuration File** — full YAML example matching the live schema; field reference table; instructions for mounting the file as a Docker volume
- **Running Navi** — `make build` + `docker run` (primary path) and local Node.js fallback
- **Development** — `make setup` / `make dev` workflow, Yarn-only dependency note, Makefile command table
- **Running Tests** — `yarn test`, `yarn lint`, `yarn report`, `yarn docs` inside the dev container
- **Roadmap** — documents planned but unimplemented items grounded in `.github/docs/flow.md`: `WorkersFactory`, read-only Web UI (React + React Bootstrap), and pending v0.0.1 release
