### PR TITLE
Create dockerfiles/dev_httpd/Dockerfile (#80)

### DIFF
--- a/dockerfiles/dev_httpd/Dockerfile
+++ b/dockerfiles/dev_httpd/Dockerfile
@@ -1,0 +1,10 @@
+FROM darthjee/node:0.2.1
+
+COPY --chown=node:node ./new-dev/ /home/node/app/
+
+USER node
+WORKDIR /home/node/app
+
+RUN yarn install
+
+CMD ["node", "app.js"]


### PR DESCRIPTION
Packages the new-dev Express app into a Docker image based on darthjee/node:0.2.1, installing dependencies via yarn and running node app.js as the default command.

Fixes #80 