### PR TITLE
docs: document dev-app classes/methods and update docs to reflect dev/ migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ All project documentation lives under [`docs/`](docs/):
 | [Architecture](docs/architecture.md) | Source layout, module system, code style, registries pattern, tooling, and implementation guidelines. |
 | [Runtime Flow](docs/flow.md) | CLI entrypoint, config loading, initial enqueueing, Engine loop, worker execution, failure handling. |
 | [Contributing](docs/contribute.md) | Explanation on how to contribute, commit and open PRs |
-| [Dev Application](docs/dev-app.md) | The sample backend used to test Navi: static (`dev/`) and dynamic Express (`new-dev/`) versions, endpoints, testing, CI jobs, and Docker Compose services. |
+| [Dev Application](docs/dev-app.md) | The sample backend used to test Navi: a dynamic Express (`dev/`) application, endpoints, classes, testing, CI jobs, and Docker Compose services. |
 | [Plans](docs/plans/) | Implementation plans for ongoing or upcoming features. |
 | [Issues](docs/issues/) | Detailed specs for open GitHub issues. |
 

--- a/dev/app.js
+++ b/dev/app.js
@@ -2,6 +2,12 @@ import express from 'express';
 import { notFound } from './lib/not_found.js';
 import Router from './lib/Router.js';
 
+/**
+ * Builds and returns a configured Express application.
+ * Registers all API routes via {@link Router} and attaches a catch-all 404 handler.
+ * @param {Object} data - Parsed YAML data to serve.
+ * @returns {import('express').Application}
+ */
 const buildApp = (data) => {
   const app = express();
   app.use(new Router(data).build());

--- a/dev/lib/DataNavigator.js
+++ b/dev/lib/DataNavigator.js
@@ -1,9 +1,22 @@
+/**
+ * Traverses a nested data structure by following a sequence of steps.
+ * Numeric steps perform an Array#find by `id`; string steps access an object key.
+ */
 class DataNavigator {
+  /**
+   * @param {Object|Array} data - Root data structure to navigate.
+   * @param {Array<string|number>} steps - Ordered navigation steps.
+   */
   constructor(data, steps) {
     this._data = data;
     this._steps = steps;
   }
 
+  /**
+   * Walks the data structure following `steps` and returns the reached value,
+   * or `null` if any intermediate step yields nothing.
+   * @returns {*}
+   */
   navigate() {
     let current = this._data;
 

--- a/dev/lib/RequestHandler.js
+++ b/dev/lib/RequestHandler.js
@@ -2,7 +2,16 @@ import DataNavigator from './DataNavigator.js';
 import { notFound } from './not_found.js';
 import RouteParamsExtractor from './RouteParamsExtractor.js';
 
+/**
+ * Handles an incoming Express request by navigating the in-memory data,
+ * optionally serializing the result, and writing the JSON response.
+ */
 class RequestHandler {
+  /**
+   * @param {string} route - Express route pattern used to derive navigation steps.
+   * @param {Object} data - Root data structure.
+   * @param {import('./Serializer.js').default|null} [serializer] - Optional serializer to project the result.
+   */
   constructor(route, data, serializer = null) {
     this._route = route;
     this._data = data;

--- a/dev/lib/RouteParamsExtractor.js
+++ b/dev/lib/RouteParamsExtractor.js
@@ -1,4 +1,12 @@
+/**
+ * Converts an Express route pattern and its resolved params into the
+ * ordered steps array expected by {@link DataNavigator}.
+ */
 class RouteParamsExtractor {
+  /**
+   * @param {string} route - Express route pattern (e.g. `/categories/:id.json`).
+   * @param {Object<string, string>} params - Resolved route params from `req.params`.
+   */
   constructor(route, params) {
     this._route = route;
     this._params = params;

--- a/dev/lib/RouteRegister.js
+++ b/dev/lib/RouteRegister.js
@@ -1,7 +1,15 @@
 import RequestHandler from './RequestHandler.js';
 import Serializer from './Serializer.js';
 
+/**
+ * Registers individual GET routes on an Express router, wiring each route
+ * to a {@link RequestHandler} and an optional {@link Serializer}.
+ */
 class RouteRegister {
+  /**
+   * @param {import('express').Router} router - Express router instance.
+   * @param {Object} data - Root data structure shared across all handlers.
+   */
   constructor(router, data) {
     this._router = router;
     this._data = data;

--- a/dev/lib/Router.js
+++ b/dev/lib/Router.js
@@ -1,11 +1,22 @@
 import { Router as ExpressRouter } from 'express';
 import RouteRegister from './RouteRegister.js';
 
+/**
+ * Builds and returns the configured Express router with all application routes
+ * registered for the categories-and-items API.
+ */
 class Router {
+  /**
+   * @param {Object} data - Parsed YAML data loaded at startup.
+   */
   constructor(data) {
     this._data = data;
   }
 
+  /**
+   * Registers all GET routes and returns the Express router.
+   * @returns {import('express').Router}
+   */
   build() {
     const router = ExpressRouter();
     const register = new RouteRegister(router, this._data);

--- a/dev/lib/Serializer.js
+++ b/dev/lib/Serializer.js
@@ -1,4 +1,11 @@
+/**
+ * Projects a data object (or array of objects) to a defined set of attributes,
+ * stripping any fields not in the allowlist.
+ */
 class Serializer {
+  /**
+   * @param {string[]} attributes - List of attribute names to keep in the output.
+   */
   constructor(attributes) {
     this._attributes = attributes;
   }

--- a/dev/lib/not_found.js
+++ b/dev/lib/not_found.js
@@ -1,1 +1,6 @@
+/**
+ * Sends a 404 JSON response with `{ error: 'Not found' }`.
+ * @param {import('express').Response} res - Express response object.
+ * @returns {void}
+ */
 export const notFound = (res) => res.status(404).json({ error: 'Not found' });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,4 +142,4 @@ When generating or modifying code:
 9. Use static factory methods (`fromObject()`, `fromListObject()`) when creating model instances from raw config objects.
 10. Always include the `.js` file extension in import statements.
 11. Each commit must be unitary and atomic: one logical change per commit, with tests and implementation in the same commit. Never bundle unrelated changes together.
-12. Every source file must act as a class declarer (define and export classes/modules), not a script. Only entrypoints (`source/bin/navi.js` and `new-dev/server.js`) may execute logic directly. Test files are exempt.
+12. Every source file must act as a class declarer (define and export classes/modules), not a script. Only entrypoints (`source/bin/navi.js` and `dev/server.js`) may execute logic directly. Test files are exempt.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -57,9 +57,9 @@ The only exceptions are **entrypoints**:
 | Application | Entrypoint |
 |-------------|-----------|
 | Main app (`source/`) | `source/bin/navi.js` |
-| Dev app (`new-dev/`) | `new-dev/server.js` |
+| Dev app (`dev/`) | `dev/server.js` |
 
-`new-dev/app.js` is the application module (exports the configured Express app) and is imported by both `server.js` and the test suite. It is not a script.
+`dev/app.js` is the application module (exports the configured Express app) and is imported by both `server.js` and the test suite. It is not a script.
 
 *Example:*
 ```js

--- a/docs/dev-app.md
+++ b/docs/dev-app.md
@@ -2,13 +2,6 @@
 
 The dev application is a sample JSON API used as the target backend when developing and testing Navi (the cache-warmer). It provides a small, predictable dataset so that Navi's HTTP requests, proxy interactions, and caching behaviour can be verified in a controlled environment.
 
-The dev app exists in two versions that are currently running in parallel:
-
-| Directory | Implementation | Status |
-|-----------|---------------|--------|
-| `dev/` | Static JSON files served by Apache httpd | Current (active) |
-| `new-dev/` | Dynamic Express/Node.js server | New version (in development) |
-
 ---
 
 ## Overview
@@ -16,82 +9,118 @@ The dev app exists in two versions that are currently running in parallel:
 Navi is configured to warm a cache by issuing HTTP requests to a backend through a reverse proxy (`navi_proxy`, powered by [tent](https://github.com/darthjee/tent)). The dev application is that backend. It exposes a simple categories-and-items REST API. Navi reads a YAML config that lists these endpoints as resources to warm, issues the requests, and the proxy caches the responses.
 
 ```
-navi_app ──► navi_proxy (tent, :3010) ──► navi_httpd / new-dev (:3020/:80)
+navi_app ──► navi_proxy (tent, :3010) ──► navi_dev_app (:3020/:80)
 ```
 
 ---
 
-## `dev/` — Static version
+## `dev/` — Express/Node.js application
 
 ### Structure
 
 ```
 dev/
-├── categories.json
-└── categories/
-    ├── 1.json
-    ├── 1/itens.json
-    ├── 2.json
-    ├── 2/itens.json
-    ├── 3.json
-    └── 3/itens.json
-```
-
-### How it works
-
-Apache httpd serves the files in `dev/` directly. Each URL maps to a file on disk. There is no routing logic — a request for `/categories/1.json` is served from `dev/categories/1.json`.
-
-### Endpoints
-
-| Method | Path | File |
-|--------|------|------|
-| GET | `/categories.json` | `dev/categories.json` |
-| GET | `/categories/:id.json` | `dev/categories/:id.json` |
-| GET | `/categories/:id/itens.json` | `dev/categories/:id/itens.json` |
-
-> Note: the items path in `dev/` is `itens.json` (Portuguese spelling). `new-dev/` uses `items.json`.
-
-### Data
-
-Three categories, each with three items:
-
-| Category | Items |
-|----------|-------|
-| Books (1) | The Hobbit, The Lord of the Rings, The Silmarillion |
-| Movies (2) | The Shawshank Redemption, The Godfather, The Dark Knight |
-| Music (3) | The Beatles, Nirvana, Queen |
-
----
-
-## `new-dev/` — Dynamic version
-
-### Structure
-
-```
-new-dev/
-├── server.js       # Entrypoint (script) — calls app.listen(80)
-├── app.js          # App module (class declarer) — exports configured Express app
-├── data.yml        # Data source (same categories/items as dev/)
+├── server.js             # Entrypoint (script) — loads data.yml and calls app.listen(80)
+├── app.js                # App module — builds and exports the configured Express app
+├── data.yml              # Data source: categories and items
 ├── package.json
 ├── eslint.config.mjs
 ├── yarn.lock
+├── lib/
+│   ├── DataNavigator.js      # Traverses the in-memory data structure
+│   ├── RequestHandler.js     # Handles a single Express request
+│   ├── RouteParamsExtractor.js # Converts route + params into navigation steps
+│   ├── RouteRegister.js      # Registers a single GET route on the router
+│   ├── Router.js             # Builds the Express router with all routes
+│   ├── Serializer.js         # Projects data objects to a set of allowed attributes
+│   └── not_found.js          # Helper that sends a 404 JSON response
 └── spec/
-    └── app_spec.js
+    ├── app_spec.js
+    ├── lib/
+    │   ├── DataNavigator_spec.js
+    │   ├── RequestHandler_spec.js
+    │   ├── RouteParamsExtractor_spec.js
+    │   ├── RouteRegister_spec.js
+    │   ├── Router_spec.js
+    │   └── Serializer_spec.js
+    └── support/
+        ├── fixtures/data.yml
+        └── utils/FixturesUtils.js
 ```
 
 ### Backend
 
 **Stack:** Node.js (ES Modules), Express 4, js-yaml
 
-**Server launcher (entrypoint):** `server.js` — imports the app and calls `listen(80)`. This is the only file in `new-dev/` that acts as a script.
+**Server launcher (entrypoint):** `server.js` — reads `data.yml` (or a path from `process.argv[2]`), parses it with js-yaml, builds the app, and calls `app.listen(80)`. This is the only file in `dev/` that acts as a script.
 
-**App module:** `app.js` — declares and exports the configured Express app (routes + middleware) without calling `listen`. Imported by both `server.js` and the test suite.
+**App module:** `app.js` — exports `buildApp(data)`, which constructs the Express application with all routes registered and a catch-all 404 handler. Imported by both `server.js` and the test suite.
 
 **Data loading:** `data.yml` is read once at startup with `readFileSync` and parsed with `js-yaml`. The result is kept in memory for the lifetime of the process.
 
+### Classes and modules
+
+#### `lib/Router`
+
+Builds and returns the configured Express router with all application routes registered.
+
+| Method | Description |
+|--------|-------------|
+| `constructor(data)` | Receives the parsed YAML data. |
+| `build()` | Creates an Express router, registers all routes via `RouteRegister`, and returns it. |
+
+#### `lib/RouteRegister`
+
+Registers individual GET routes on an Express router, wiring each route to a `RequestHandler` and an optional `Serializer`.
+
+| Method | Description |
+|--------|-------------|
+| `constructor(router, data)` | Receives the Express router and the root data structure. |
+| `register({ route, attributes })` | Registers a GET handler; if `attributes` is provided, a `Serializer` is created to project the response. |
+
+#### `lib/RequestHandler`
+
+Handles an incoming Express request by navigating the in-memory data, optionally serializing the result, and writing the JSON response.
+
+| Method | Description |
+|--------|-------------|
+| `constructor(route, data, serializer?)` | Receives the route pattern, root data, and an optional `Serializer`. |
+| `handle(req, res)` | Extracts navigation steps, navigates the data, and responds with JSON (or 404 if nothing was found). |
+
+#### `lib/RouteParamsExtractor`
+
+Converts an Express route pattern and its resolved params into the ordered steps array expected by `DataNavigator`.
+
+| Method | Description |
+|--------|-------------|
+| `constructor(route, params)` | Receives the route pattern and the `req.params` object. |
+| `steps()` | Returns `Array<string\|number>` — string segments become object-key steps; `:param` segments become numeric ID steps. |
+
+#### `lib/DataNavigator`
+
+Traverses a nested data structure by following a sequence of steps. Numeric steps perform an `Array#find` by `id`; string steps access an object key.
+
+| Method | Description |
+|--------|-------------|
+| `constructor(data, steps)` | Receives the root data structure and the steps array. |
+| `navigate()` | Walks the data following `steps` and returns the reached value, or `null` if any step yields nothing. |
+
+#### `lib/Serializer`
+
+Projects a data object (or array of objects) to a defined set of attributes, stripping any fields not in the allowlist.
+
+| Method | Description |
+|--------|-------------|
+| `constructor(attributes)` | Receives the list of attribute names to keep. |
+| `serialize(data)` | Returns a projected object or array; arrays are mapped recursively. |
+
+#### `lib/not_found`
+
+Utility function: `notFound(res)` — sends a 404 response with `{ "error": "Not found" }`.
+
 ### Routes
 
-All routes are registered in `app.js`:
+All routes are registered in `Router#build()` via `RouteRegister#register()`:
 
 | Method | Path | Description | Response |
 |--------|------|-------------|----------|
@@ -106,37 +135,51 @@ All responses are JSON. Errors return `{"error": "Not found"}` with status 404.
 ### Request lifecycle
 
 1. Express matches the incoming path against the registered routes (top to bottom).
-2. For parameterised routes, `req.params.id` (and `req.params.item_id`) are coerced to `Number` for the `Array#find` lookup.
-3. If no matching record is found, the handler returns early with `res.status(404).json(…)`.
-4. The catch-all `app.use` at the bottom handles any path that matched no route.
+2. `RouteParamsExtractor` converts the route pattern and `req.params` into a steps array.
+3. `DataNavigator` follows the steps through the in-memory data.
+4. If no matching record is found, `notFound(res)` responds with 404.
+5. Otherwise, the result is optionally projected by `Serializer` and returned as JSON.
+6. The catch-all `app.use` at the bottom handles any path that matched no route.
+
+### Data (`data.yml`)
+
+Three categories, each with three items:
+
+| Category | Items |
+|----------|-------|
+| Books (1) | The Hobbit, The Lord of the Rings, The Silmarillion |
+| Movies (2) | The Shawshank Redemption, The Godfather, The Dark Knight |
+| Music (3) | The Beatles, Nirvana, Queen |
 
 ### How to add a new endpoint
 
 1. Add the data to `data.yml` under the appropriate key.
-2. Register a new `app.get(…)` handler in `app.js` before the catch-all `app.use`.
-3. Write a corresponding `describe` block in `spec/app_spec.js` covering the happy path and the 404 case.
+2. Call `register.register(…)` in `Router#build()` before returning the router.
+3. Write a corresponding `describe` block in `spec/lib/Router_spec.js` and in `spec/app_spec.js` covering the happy path and the 404 case.
 
 ---
 
-## Testing (`new-dev/`)
+## Testing
 
 **Framework:** Jasmine 5 + Supertest 7
 
-Tests live in `new-dev/spec/app_spec.js`. They import the Express app directly (no server needed) and use Supertest to issue HTTP requests in-process.
+Tests live in `spec/`. They import the Express app (or individual classes) directly and use Supertest to issue HTTP requests in-process — no running server is required.
 
-### What is covered
+### Test files
 
-| Describe block | Cases |
-|----------------|-------|
-| `GET /categories.json` | 200 + non-empty array + no nested items |
-| `GET /categories/:id.json` | 200 for valid ID; 404 for unknown ID |
-| `GET /categories/:id/items.json` | 200 + non-empty array; 404 for unknown category |
-| `GET /categories/:id/items/:item_id.json` | 200 for valid IDs; 404 for unknown item |
-| Unmatched routes | 404 for `/unknown` |
+| File | What it covers |
+|------|---------------|
+| `spec/app_spec.js` | End-to-end route tests through the full app |
+| `spec/lib/Router_spec.js` | All routes registered by `Router#build()` |
+| `spec/lib/RouteRegister_spec.js` | Route registration and serializer wiring |
+| `spec/lib/RequestHandler_spec.js` | Data navigation, serialization, and 404 handling |
+| `spec/lib/RouteParamsExtractor_spec.js` | Steps extraction from route patterns and params |
+| `spec/lib/DataNavigator_spec.js` | Navigation through nested data structures |
+| `spec/lib/Serializer_spec.js` | Attribute projection for objects and arrays |
 
 ### Running tests
 
-Inside the `new-dev/` directory:
+Inside the `dev/` directory:
 
 ```bash
 yarn test       # Run tests with c8 coverage (text + HTML)
@@ -144,8 +187,6 @@ yarn coverage   # Run tests and produce coverage/lcov.info (for CI)
 yarn lint       # ESLint
 yarn report     # JSCPD duplication analysis
 ```
-
-There is no dedicated Docker service for `new-dev/` tests yet. Tests run directly via the CircleCI `jasmine-dev` job using the `darthjee/circleci_node:0.2.1` image.
 
 ---
 
@@ -155,8 +196,8 @@ There is no dedicated Docker service for `new-dev/` tests yet. Tests run directl
 |-----|-----------|-------------|
 | `jasmine` | `source/` | Runs Navi's own tests + uploads coverage to Codacy (partial) |
 | `checks` | `source/` | ESLint + JSCPD |
-| `jasmine-dev` | `new-dev/` | Runs dev-app tests + uploads coverage to Codacy (partial) |
-| `checks-dev` | `new-dev/` | ESLint + JSCPD |
+| `jasmine-dev` | `dev/` | Runs dev-app tests + uploads coverage to Codacy (partial) |
+| `checks-dev` | `dev/` | ESLint + JSCPD |
 | `coverage-final` | — | Sends the Codacy `final` signal after both partial uploads complete |
 
 `jasmine-dev` and `checks-dev` mirror the structure of `jasmine` and `checks`. `coverage-final` depends on both `jasmine` and `jasmine-dev` so Codacy receives a combined coverage report from both applications.
@@ -169,38 +210,18 @@ All jobs run on every push and every tag. There are no branch restrictions on th
 
 | Service | Image | Port | Purpose |
 |---------|-------|------|---------|
-| `navi_httpd` | `httpd` | `3020:80` | Serves static files from `dev/` (Apache) |
-| `navi_proxy` | `darthjee/tent:0.5.0` | `3010:80` | Reverse-proxy + caching layer in front of `navi_httpd` |
+| `navi_dev_app` | `navi_app:dev` | `3020:80` | Runs the Express dev app from `dev/` |
+| `navi_proxy` | `darthjee/tent:0.5.0` | `3010:80` | Reverse-proxy + caching layer in front of `navi_dev_app` |
 | `navi_app` | `navi:dev` | — | Navi application container; linked to `navi_proxy` as `remote_host` |
 | `navi_tests` | `navi:dev` | — | Test/lint container for `source/` |
-
-`new-dev/` does not have a dedicated Docker Compose service yet. Its tests run directly in CI without Docker.
 
 ### Dependency chain
 
 ```
-navi_app ──depends_on──► navi_proxy ──depends_on──► navi_httpd
+navi_app ──depends_on──► navi_proxy ──depends_on──► navi_dev_app
 navi_tests ──depends_on──► base_build
 ```
 
 ### Environment variables
 
 The services use an `.env` file (copied from `.env.sample` during `make setup`). No dev-app-specific environment variables are required beyond what the base image provides.
-
----
-
-## Differences between `dev/` and `new-dev/`
-
-| Aspect | `dev/` | `new-dev/` |
-|--------|--------|------------|
-| Implementation | Static JSON files | Express/Node.js app |
-| Server | Apache httpd (Docker image `httpd`) | Node.js (`server.js` → `app.listen(80)`); `app.js` exports the app module |
-| Data source | Individual `.json` files on disk | Single `data.yml` file loaded at startup |
-| Items path | `/categories/:id/itens.json` (Portuguese) | `/categories/:id/items.json` (English) |
-| 404 handling | Apache default 404 page | JSON `{"error": "Not found"}` |
-| Test suite | None | Jasmine + Supertest (`spec/app_spec.js`) |
-| Coverage | None | c8 → `coverage/lcov.info` |
-| Linting | None | ESLint with flat config (`eslint.config.mjs`) |
-| Duplication check | None | JSCPD |
-| Docker Compose service | `navi_httpd` | Not yet added |
-| Dependencies | None (pure static) | `express`, `js-yaml` |


### PR DESCRIPTION
## Summary

Documents all classes and modules in the dev-app and updates all documentation to reflect that the migration from the old static Apache version (`dev/`) and the Express version (`new-dev/`) is complete — `new-dev/` has been renamed to `dev/`.

## Changes

### JSDoc added to `dev/`

All public classes and functions in `dev/lib/` and `dev/app.js` now have JSDoc:

- `lib/DataNavigator` — class, constructor, `navigate()`
- `lib/RequestHandler` — class, constructor
- `lib/RouteParamsExtractor` — class, constructor
- `lib/RouteRegister` — class, constructor
- `lib/Router` — class, constructor, `build()`
- `lib/Serializer` — class, constructor
- `lib/not_found` — `notFound()` function
- `app.js` — `buildApp()` function

### Documentation updated

- **`docs/dev-app.md`** — Fully rewritten: removed the static Apache section and the `new-dev/` section; now documents the single `dev/` Express application, its directory structure, all classes/methods, routes, request lifecycle, testing, CI jobs, and Docker Compose services.
- **`docs/contributing.md`** — Updated entrypoint table: `new-dev/server.js` → `dev/server.js`.
- **`docs/architecture.md`** — Updated rule 12: `new-dev/server.js` → `dev/server.js`.
- **`AGENTS.md`** — Updated dev-app table description to reflect the single `dev/` app.

