### PR TITLE
feat: add processing IdentifyableCollection to JobRegistry

### DIFF
--- a/source/lib/registry/JobRegistry.js
+++ b/source/lib/registry/JobRegistry.js
@@ -12,6 +12,7 @@ class JobRegistry {
   #failed;
   #finished;
   #dead;
+  #processing;
   #lockedBy;
   #factory;
 
@@ -22,15 +23,17 @@ class JobRegistry {
    * @param {ClientRegistry} options.clients - The clients to be used by the JobFactory.
    * @param {Queue} [options.queue] - An optional queue to use for enqueued jobs. If not provided, a new Queue will be created.
    * @param {Queue} [options.failed] - An optional queue to use for failed jobs. If not provided, a new Queue will be created.
-   * @param {Queue} [options.finished] - An optional queue to use for finished jobs. If not provided, a new Queue will be created.
-   * @param {Queue} [options.dead] - An optional queue to use for dead jobs. If not provided, a new Queue will be created.
+   * @param {IdentifyableCollection} [options.finished] - An optional collection to use for finished jobs. If not provided, a new IdentifyableCollection will be created.
+   * @param {IdentifyableCollection} [options.dead] - An optional collection to use for dead jobs. If not provided, a new IdentifyableCollection will be created.
+   * @param {IdentifyableCollection} [options.processing] - An optional collection to use for jobs currently being processed. If not provided, a new IdentifyableCollection will be created.
    * @param {JobFactory} [options.factory] - An optional JobFactory to use for creating jobs. If not provided, a new JobFactory will be created with the provided clients.
    */
-  constructor({ queue, failed, finished, dead, clients, factory }) {
+  constructor({ queue, failed, finished, dead, processing, clients, factory }) {
     this.#enqueued = queue || new Queue();
     this.#failed = failed || new Queue();
     this.#finished = finished || new IdentifyableCollection();
     this.#dead = dead || new IdentifyableCollection();
+    this.#processing = processing || new IdentifyableCollection();
 
     this.#lockedBy = null;
     this.#factory = factory || new JobFactory({ clients });
@@ -51,10 +54,13 @@ class JobRegistry {
 
   /**
    * Marks a job as failed.
+   * Removes the job from processing before queuing it for retry or marking it as dead.
    * @param {Job} job - The job to mark as failed.
    * @returns {void}
    */
   fail(job) {
+    if (!job) return;
+    this.#processing.remove(job.id);
     if (job.exhausted()) {
       this.#dead.push(job);
     } else {
@@ -64,19 +70,26 @@ class JobRegistry {
 
   /**
    * Marks a job as finished.
+   * Removes the job from processing before adding it to the finished collection.
    * @param {Job} job - The job to mark as finished.
    * @returns {void}
    */
   finish(job) {
+    if (!job) return;
+    this.#processing.remove(job.id);
     this.#finished.push(job);
   }
 
   /**
-   * Picks (removes and returns) the first job from the queue.
+   * Picks (removes and returns) the first job from the queue and adds it to processing.
    * @returns {Job|undefined} The first job in the queue, or undefined if empty.
    */
   pick() {
-    return this.#enqueued.pick() || this.#failed.pick();
+    const job = this.#enqueued.pick() || this.#failed.pick();
+    if (job) {
+      this.#processing.push(job);
+    }
+    return job;
   }
 
   /**

--- a/source/spec/registry/JobRegistry_spec.js
+++ b/source/spec/registry/JobRegistry_spec.js
@@ -3,6 +3,7 @@ import { Job } from '../../lib/models/Job.js';
 import { Worker } from '../../lib/models/Worker.js';
 import { ClientRegistry } from '../../lib/registry/ClientRegistry.js';
 import { JobRegistry } from '../../lib/registry/JobRegistry.js';
+import { IdentifyableCollection } from '../../lib/utils/IdentifyableCollection.js';
 import { Queue } from '../../lib/utils/Queue.js';
 import { ResourceRequestFactory } from '../support/factories/ResourceRequestFactory.js';
 
@@ -14,13 +15,15 @@ describe('JobRegistry', () => {
   let jobs;
   let failedJobs;
   let finished;
+  let processing;
 
   beforeEach(() => {
     clients = new ClientRegistry();
     jobs = new Queue();
     failedJobs = new Queue();
     finished = new Queue();
-    registry = new JobRegistry({ jobs, failedJobs, finished, clients });
+    processing = new IdentifyableCollection();
+    registry = new JobRegistry({ jobs, failedJobs, finished, processing, clients });
     resourceRequest = ResourceRequestFactory.build({ url: 'http://example.com' });
   });
 
@@ -59,6 +62,12 @@ describe('JobRegistry', () => {
       it('returns undefined', () => {
         expect(registry.pick()).toBeUndefined();
       });
+
+      it('does not add anything to processing', () => {
+        registry.pick();
+
+        expect(processing.hasAny()).toBeFalse();
+      });
     });
 
     describe('when the queue has jobs', () => {
@@ -87,6 +96,12 @@ describe('JobRegistry', () => {
         registry.pick();
 
         expect(registry.hasJob()).toBeFalse();
+      });
+
+      it('adds the picked job to processing', () => {
+        const job = registry.pick();
+
+        expect(processing.has(job.id)).toBeTrue();
       });
     });
 
@@ -227,6 +242,17 @@ describe('JobRegistry', () => {
       expect(registry.hasJob()).toBeTrue();
       expect(registry.pick()).toEqual(job);
     });
+
+    it('removes the job from processing', () => {
+      const job = registry.enqueue({ parameters: { value: 1 } });
+      const picked = registry.pick();
+
+      expect(processing.has(picked.id)).toBeTrue();
+
+      registry.fail(job);
+
+      expect(processing.has(picked.id)).toBeFalse();
+    });
   });
 
   describe('#finish', () => {
@@ -244,6 +270,17 @@ describe('JobRegistry', () => {
 
     it('is safe to call with undefined', () => {
       expect(() => registry.finish(undefined)).not.toThrow();
+    });
+
+    it('removes the job from processing', () => {
+      const job = registry.enqueue({ parameters: { value: 1 } });
+      const picked = registry.pick();
+
+      expect(processing.has(picked.id)).toBeTrue();
+
+      registry.finish(job);
+
+      expect(processing.has(picked.id)).toBeFalse();
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a `#processing` `IdentifyableCollection` to `JobRegistry` to track jobs currently being processed by a worker — analogous to the existing `#failed` and `#finished` collections.

## Changes

### `source/lib/registry/JobRegistry.js`
- Added `#processing` private field (`IdentifyableCollection`)
- Constructor now accepts an optional `processing` injection parameter
- **`pick()`**: after removing the job from the enqueued/failed queue, adds it to `#processing`
- **`fail(job)`**: removes the job from `#processing` before adding it to the dead or failed queue; guards against `undefined` job
- **`finish(job)`**: removes the job from `#processing` before adding it to finished; guards against `undefined` job

### `source/spec/registry/JobRegistry_spec.js`
- Imports `IdentifyableCollection` and injects a `processing` collection in `beforeEach`
- New tests for:
  - `pick()` — adds the job to processing; does nothing to processing when queue is empty
  - `fail()` — removes the job from processing
  - `finish()` — removes the job from processing

## Validation
- 207 specs, 0 failures
- ESLint: 0 errors (pre-existing console warnings only)
- CodeQL: 0 alerts