### PR TITLE
Add static convenience methods to Logger via singleton default instance, backed by BaseLogger and ConsoleLogger

### DIFF
--- a/source/lib/models/Worker.js
+++ b/source/lib/models/Worker.js
@@ -1,4 +1,4 @@
-import { Logger } from '../utils/Logger.js';
+import { ConsoleLogger } from '../utils/ConsoleLogger.js';
 
 /**
  * Worker processes jobs pulled from a JobRegistry.
@@ -18,7 +18,7 @@ class Worker {
     this.id = id;
     this.jobRegistry = jobRegistry;
     this.workerRegistry = workerRegistry;
-    this.#logger = new Logger();
+    this.#logger = new ConsoleLogger();
   }
 
   /**

--- a/source/lib/utils/BaseLogger.js
+++ b/source/lib/utils/BaseLogger.js
@@ -1,0 +1,93 @@
+/**
+ * Base logger that filters log output based on a configurable level threshold.
+ * Subclasses must implement _output(level, message) to handle the actual output.
+ * @author darthjee
+ */
+class BaseLogger {
+  #level;
+  #suppressed = false;
+  #levels = { debug: 0, info: 1, warn: 2, error: 3, silent: 4 };
+
+  /**
+   * Creates a new BaseLogger instance.
+   * @param {string} [level] - The log level threshold. Defaults to the LOG_LEVEL env var or 'info'.
+   */
+  constructor(level) {
+    this.#level = level ?? process.env.LOG_LEVEL ?? 'info';
+  }
+
+  /**
+   * @param {string} level - The log level to check.
+   * @returns {boolean} True if the message should be logged at the given level.
+   */
+  #shouldLog(level) {
+    return !this.#suppressed && this.#levels[level] >= this.#levels[this.#level];
+  }
+
+  /**
+   * Outputs a message at the given level. Override in subclasses.
+   * @param {string} _level - The log level.
+   * @param {string} _message - The message to output.
+   * @returns {void}
+   */
+  _output(_level, _message) {}
+
+  /**
+   * Logs a debug message if the configured level allows it.
+   * @param {string} message - The message to log.
+   * @returns {void}
+   */
+  debug(message) {
+    if (this.#shouldLog('debug')) this._output('debug', message);
+  }
+
+  /**
+   * Logs an info message if the configured level allows it.
+   * @param {string} message - The message to log.
+   * @returns {void}
+   */
+  info(message) {
+    if (this.#shouldLog('info')) this._output('info', message);
+  }
+
+  /**
+   * Logs a warn message if the configured level allows it.
+   * @param {string} message - The message to log.
+   * @returns {void}
+   */
+  warn(message) {
+    if (this.#shouldLog('warn')) this._output('warn', message);
+  }
+
+  /**
+   * Logs an error message if the configured level allows it.
+   * @param {string} message - The message to log.
+   * @returns {void}
+   */
+  error(message) {
+    if (this.#shouldLog('error')) this._output('error', message);
+  }
+
+  /**
+   * Suppresses or restores log output for this instance.
+   * @param {boolean} [value=true] - When true, all log output is suppressed.
+   * @returns {void}
+   */
+  suppress(value = true) {
+    this.#suppressed = value;
+  }
+
+  /**
+   * Sets the log level threshold for this instance.
+   * @param {string} level - The new log level ('debug', 'info', 'warn', 'error', 'silent').
+   * @returns {void}
+   */
+  setLevel(level) {
+    if (!(level in this.#levels)) {
+      throw new Error(`Invalid log level: "${level}". Must be one of: ${Object.keys(this.#levels).join(', ')}.`);
+    }
+    this.#level = level;
+  }
+}
+
+export { BaseLogger };

--- a/source/lib/utils/ConsoleLogger.js
+++ b/source/lib/utils/ConsoleLogger.js
@@ -1,0 +1,19 @@
+import { BaseLogger } from './BaseLogger.js';
+
+/**
+ * Logger that writes output to the browser/Node.js console.
+ * @author darthjee
+ */
+class ConsoleLogger extends BaseLogger {
+  /**
+   * Writes a message to the console at the given level.
+   * @param {string} level - One of 'debug', 'info', 'warn', 'error'.
+   * @param {string} message - The message to output.
+   * @returns {void}
+   */
+  _output(level, message) {
+    console[level](message); // eslint-disable-line no-console
+  }
+}
+
+export { ConsoleLogger };

--- a/source/lib/utils/Logger.js
+++ b/source/lib/utils/Logger.js
@@ -1,61 +1,95 @@
+import { ConsoleLogger } from './ConsoleLogger.js';
+
 /**
- * Logger utility that filters log output based on a configurable level threshold.
+ * Static facade for the default ConsoleLogger singleton.
+ * All instance-level log logic lives in BaseLogger / ConsoleLogger.
  * @author darthjee
  */
 class Logger {
-  #level;
-  #levels = { debug: 0, info: 1, warn: 2, error: 3, silent: 4 };
+  static #defaultInstance;
 
   /**
-   * Creates a new Logger instance.
-   * @param {string} [level] - The log level threshold. Defaults to the LOG_LEVEL env var or 'info'.
+   * Returns the default ConsoleLogger instance (singleton).
+   * @returns {ConsoleLogger} The default logger instance.
    */
-  constructor(level) {
-    this.#level = level ?? process.env.LOG_LEVEL ?? 'info';
+  static default() {
+    if (!this.#defaultInstance) {
+      this.#defaultInstance = new ConsoleLogger();
+    }
+    return this.#defaultInstance;
   }
 
   /**
-   * @param {string} level - The log level to check.
-   * @returns {boolean} True if the message should be logged at the given level.
-   */
-  #shouldLog(level) {
-    return this.#levels[level] >= this.#levels[this.#level];
-  }
-
-  /**
-   * Logs a debug message if the configured level allows it.
+   * Logs a debug message using the default logger instance.
    * @param {string} message - The message to log.
    * @returns {void}
    */
-  debug(message) {
-    if (this.#shouldLog('debug')) console.debug(message); // eslint-disable-line no-console
+  static debug(message) {
+    this.default().debug(message);
   }
 
   /**
-   * Logs an info message if the configured level allows it.
+   * Logs an info message using the default logger instance.
    * @param {string} message - The message to log.
    * @returns {void}
    */
-  info(message) {
-    if (this.#shouldLog('info')) console.info(message); // eslint-disable-line no-console
+  static info(message) {
+    this.default().info(message);
   }
 
   /**
-   * Logs a warn message if the configured level allows it.
+   * Logs a warn message using the default logger instance.
    * @param {string} message - The message to log.
    * @returns {void}
    */
-  warn(message) {
-    if (this.#shouldLog('warn')) console.warn(message); // eslint-disable-line no-console
+  static warn(message) {
+    this.default().warn(message);
   }
 
   /**
-   * Logs an error message if the configured level allows it.
+   * Logs an error message using the default logger instance.
    * @param {string} message - The message to log.
    * @returns {void}
    */
-  error(message) {
-    if (this.#shouldLog('error')) console.error(message); // eslint-disable-line no-console
+  static error(message) {
+    this.default().error(message);
+  }
+
+  /**
+   * Suppresses or restores log output on the default logger instance.
+   * @param {boolean} [value=true] - When true, all log output is suppressed.
+   * @returns {void}
+   */
+  static suppress(value = true) {
+    this.default().suppress(value);
+  }
+
+  /**
+   * Sets the log level threshold on the default logger instance.
+   * @param {string} level - The new log level ('debug', 'info', 'warn', 'error', 'silent').
+   * @returns {void}
+   */
+  static setLevel(level) {
+    this.default().setLevel(level);
+  }
+
+  /**
+   * Resets the default logger instance so a new one is created on the next call to default().
+   * Useful in tests to ensure a clean singleton state.
+   * @returns {void}
+   */
+  static reset() {
+    this.#defaultInstance = null;
+  }
+
+  /**
+   * Sets the default logger instance to the provided logger.
+   * Useful in tests to inject a mock or custom logger.
+   * @param {ConsoleLogger} newLogger - The logger instance to use as the default.
+   * @returns {void}
+   */
+  static setDefault(newLogger) {
+    this.#defaultInstance = newLogger;
   }
 }
 

--- a/source/spec/utils/BaseLogger_spec.js
+++ b/source/spec/utils/BaseLogger_spec.js
@@ -1,0 +1,214 @@
+import { BaseLogger } from '../../lib/utils/BaseLogger.js';
+
+describe('BaseLogger', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = new BaseLogger('info');
+    spyOn(logger, '_output');
+  });
+
+  describe('default level (info)', () => {
+    it('does not output debug messages', () => {
+      logger.debug('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('outputs info messages', () => {
+      logger.info('msg');
+      expect(logger._output).toHaveBeenCalledWith('info', 'msg');
+    });
+
+    it('outputs warn messages', () => {
+      logger.warn('msg');
+      expect(logger._output).toHaveBeenCalledWith('warn', 'msg');
+    });
+
+    it('outputs error messages', () => {
+      logger.error('msg');
+      expect(logger._output).toHaveBeenCalledWith('error', 'msg');
+    });
+  });
+
+  describe('with level debug', () => {
+    beforeEach(() => {
+      logger = new BaseLogger('debug');
+      spyOn(logger, '_output');
+    });
+
+    it('outputs debug messages', () => {
+      logger.debug('msg');
+      expect(logger._output).toHaveBeenCalledWith('debug', 'msg');
+    });
+
+    it('outputs info messages', () => {
+      logger.info('msg');
+      expect(logger._output).toHaveBeenCalledWith('info', 'msg');
+    });
+
+    it('outputs warn messages', () => {
+      logger.warn('msg');
+      expect(logger._output).toHaveBeenCalledWith('warn', 'msg');
+    });
+
+    it('outputs error messages', () => {
+      logger.error('msg');
+      expect(logger._output).toHaveBeenCalledWith('error', 'msg');
+    });
+  });
+
+  describe('with level warn', () => {
+    beforeEach(() => {
+      logger = new BaseLogger('warn');
+      spyOn(logger, '_output');
+    });
+
+    it('does not output debug messages', () => {
+      logger.debug('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('does not output info messages', () => {
+      logger.info('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('outputs warn messages', () => {
+      logger.warn('msg');
+      expect(logger._output).toHaveBeenCalledWith('warn', 'msg');
+    });
+
+    it('outputs error messages', () => {
+      logger.error('msg');
+      expect(logger._output).toHaveBeenCalledWith('error', 'msg');
+    });
+  });
+
+  describe('with level error', () => {
+    beforeEach(() => {
+      logger = new BaseLogger('error');
+      spyOn(logger, '_output');
+    });
+
+    it('does not output debug messages', () => {
+      logger.debug('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('does not output info messages', () => {
+      logger.info('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('does not output warn messages', () => {
+      logger.warn('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('outputs error messages', () => {
+      logger.error('msg');
+      expect(logger._output).toHaveBeenCalledWith('error', 'msg');
+    });
+  });
+
+  describe('with level silent', () => {
+    beforeEach(() => {
+      logger = new BaseLogger('silent');
+      spyOn(logger, '_output');
+    });
+
+    it('does not output debug messages', () => {
+      logger.debug('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('does not output info messages', () => {
+      logger.info('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('does not output warn messages', () => {
+      logger.warn('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('does not output error messages', () => {
+      logger.error('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with LOG_LEVEL env var', () => {
+    let originalLevel;
+
+    beforeEach(() => {
+      originalLevel = process.env.LOG_LEVEL;
+      process.env.LOG_LEVEL = 'warn';
+      logger = new BaseLogger();
+      spyOn(logger, '_output');
+    });
+
+    afterEach(() => {
+      if (originalLevel === undefined) {
+        delete process.env.LOG_LEVEL;
+      } else {
+        process.env.LOG_LEVEL = originalLevel;
+      }
+    });
+
+    it('uses LOG_LEVEL from environment', () => {
+      logger.info('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+      logger.warn('msg');
+      expect(logger._output).toHaveBeenCalledWith('warn', 'msg');
+    });
+  });
+
+  describe('#suppress', () => {
+    describe('when called with no argument (default true)', () => {
+      beforeEach(() => {
+        logger.suppress();
+      });
+
+      it('suppresses info messages', () => {
+        logger.info('msg');
+        expect(logger._output).not.toHaveBeenCalled();
+      });
+
+      it('suppresses error messages', () => {
+        logger.error('msg');
+        expect(logger._output).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when called with false after suppressing', () => {
+      beforeEach(() => {
+        logger.suppress(true);
+        logger.suppress(false);
+      });
+
+      it('restores output', () => {
+        logger.info('msg');
+        expect(logger._output).toHaveBeenCalledWith('info', 'msg');
+      });
+    });
+  });
+
+  describe('#setLevel', () => {
+    it('lowers the level to allow previously-suppressed messages', () => {
+      logger.setLevel('debug');
+      logger.debug('msg');
+      expect(logger._output).toHaveBeenCalledWith('debug', 'msg');
+    });
+
+    it('raises the level to suppress previously-logged messages', () => {
+      logger.setLevel('warn');
+      logger.info('msg');
+      expect(logger._output).not.toHaveBeenCalled();
+    });
+
+    it('throws for an invalid level', () => {
+      expect(() => logger.setLevel('verbose')).toThrowError(/Invalid log level/);
+    });
+  });
+});

--- a/source/spec/utils/ConsoleLogger_spec.js
+++ b/source/spec/utils/ConsoleLogger_spec.js
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+import { ConsoleLogger } from '../../lib/utils/ConsoleLogger.js';
+
+describe('ConsoleLogger', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = new ConsoleLogger('debug');
+    spyOn(console, 'debug').and.stub();
+    spyOn(console, 'info').and.stub();
+    spyOn(console, 'warn').and.stub();
+    spyOn(console, 'error').and.stub();
+  });
+
+  it('routes debug messages to console.debug', () => {
+    logger.debug('msg');
+    expect(console.debug).toHaveBeenCalledWith('msg');
+  });
+
+  it('routes info messages to console.info', () => {
+    logger.info('msg');
+    expect(console.info).toHaveBeenCalledWith('msg');
+  });
+
+  it('routes warn messages to console.warn', () => {
+    logger.warn('msg');
+    expect(console.warn).toHaveBeenCalledWith('msg');
+  });
+
+  it('routes error messages to console.error', () => {
+    logger.error('msg');
+    expect(console.error).toHaveBeenCalledWith('msg');
+  });
+});

--- a/source/spec/utils/Logger_spec.js
+++ b/source/spec/utils/Logger_spec.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { ConsoleLogger } from '../../lib/utils/ConsoleLogger.js';
 import { Logger } from '../../lib/utils/Logger.js';
 
 describe('Logger', () => {
@@ -9,169 +10,100 @@ describe('Logger', () => {
     spyOn(console, 'error').and.stub();
   });
 
-  describe('default level (info)', () => {
-    let logger;
-
-    beforeEach(() => {
-      logger = new Logger();
+  describe('.default', () => {
+    it('returns a ConsoleLogger instance', () => {
+      expect(Logger.default()).toBeInstanceOf(ConsoleLogger);
     });
 
-    it('does not log debug messages', () => {
-      logger.debug('msg');
-      expect(console.debug).not.toHaveBeenCalled();
-    });
-
-    it('logs info messages', () => {
-      logger.info('msg');
-      expect(console.info).toHaveBeenCalledWith('msg');
-    });
-
-    it('logs warn messages', () => {
-      logger.warn('msg');
-      expect(console.warn).toHaveBeenCalledWith('msg');
-    });
-
-    it('logs error messages', () => {
-      logger.error('msg');
-      expect(console.error).toHaveBeenCalledWith('msg');
+    it('returns the same instance on successive calls (singleton)', () => {
+      expect(Logger.default()).toBe(Logger.default());
     });
   });
 
-  describe('with level debug', () => {
-    let logger;
-
-    beforeEach(() => {
-      logger = new Logger('debug');
-    });
-
-    it('logs debug messages', () => {
-      logger.debug('msg');
-      expect(console.debug).toHaveBeenCalledWith('msg');
-    });
-
-    it('logs info messages', () => {
-      logger.info('msg');
-      expect(console.info).toHaveBeenCalledWith('msg');
-    });
-
-    it('logs warn messages', () => {
-      logger.warn('msg');
-      expect(console.warn).toHaveBeenCalledWith('msg');
-    });
-
-    it('logs error messages', () => {
-      logger.error('msg');
-      expect(console.error).toHaveBeenCalledWith('msg');
+  describe('.debug', () => {
+    it('delegates to the default logger instance', () => {
+      spyOn(Logger.default(), 'debug');
+      Logger.debug('static debug msg');
+      expect(Logger.default().debug).toHaveBeenCalledWith('static debug msg');
     });
   });
 
-  describe('with level warn', () => {
-    let logger;
-
-    beforeEach(() => {
-      logger = new Logger('warn');
-    });
-
-    it('does not log debug messages', () => {
-      logger.debug('msg');
-      expect(console.debug).not.toHaveBeenCalled();
-    });
-
-    it('does not log info messages', () => {
-      logger.info('msg');
-      expect(console.info).not.toHaveBeenCalled();
-    });
-
-    it('logs warn messages', () => {
-      logger.warn('msg');
-      expect(console.warn).toHaveBeenCalledWith('msg');
-    });
-
-    it('logs error messages', () => {
-      logger.error('msg');
-      expect(console.error).toHaveBeenCalledWith('msg');
+  describe('.info', () => {
+    it('delegates to the default logger instance', () => {
+      spyOn(Logger.default(), 'info');
+      Logger.info('static info msg');
+      expect(Logger.default().info).toHaveBeenCalledWith('static info msg');
     });
   });
 
-  describe('with level error', () => {
-    let logger;
-
-    beforeEach(() => {
-      logger = new Logger('error');
-    });
-
-    it('does not log debug messages', () => {
-      logger.debug('msg');
-      expect(console.debug).not.toHaveBeenCalled();
-    });
-
-    it('does not log info messages', () => {
-      logger.info('msg');
-      expect(console.info).not.toHaveBeenCalled();
-    });
-
-    it('does not log warn messages', () => {
-      logger.warn('msg');
-      expect(console.warn).not.toHaveBeenCalled();
-    });
-
-    it('logs error messages', () => {
-      logger.error('msg');
-      expect(console.error).toHaveBeenCalledWith('msg');
+  describe('.warn', () => {
+    it('delegates to the default logger instance', () => {
+      spyOn(Logger.default(), 'warn');
+      Logger.warn('static warn msg');
+      expect(Logger.default().warn).toHaveBeenCalledWith('static warn msg');
     });
   });
 
-  describe('with level silent', () => {
-    let logger;
-
-    beforeEach(() => {
-      logger = new Logger('silent');
-    });
-
-    it('does not log debug messages', () => {
-      logger.debug('msg');
-      expect(console.debug).not.toHaveBeenCalled();
-    });
-
-    it('does not log info messages', () => {
-      logger.info('msg');
-      expect(console.info).not.toHaveBeenCalled();
-    });
-
-    it('does not log warn messages', () => {
-      logger.warn('msg');
-      expect(console.warn).not.toHaveBeenCalled();
-    });
-
-    it('does not log error messages', () => {
-      logger.error('msg');
-      expect(console.error).not.toHaveBeenCalled();
+  describe('.error', () => {
+    it('delegates to the default logger instance', () => {
+      spyOn(Logger.default(), 'error');
+      Logger.error('static error msg');
+      expect(Logger.default().error).toHaveBeenCalledWith('static error msg');
     });
   });
 
-  describe('with LOG_LEVEL env var', () => {
-    let logger;
-    let originalLevel;
+  describe('.suppress', () => {
+    it('delegates to the default logger instance', () => {
+      spyOn(Logger.default(), 'suppress');
+      Logger.suppress(true);
+      expect(Logger.default().suppress).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('.setLevel', () => {
+    it('delegates to the default logger instance', () => {
+      spyOn(Logger.default(), 'setLevel');
+      Logger.setLevel('debug');
+      expect(Logger.default().setLevel).toHaveBeenCalledWith('debug');
+    });
+  });
+
+  describe('.reset', () => {
+    let instanceBeforeReset;
 
     beforeEach(() => {
-      originalLevel = process.env.LOG_LEVEL;
-      process.env.LOG_LEVEL = 'warn';
-      logger = new Logger();
+      instanceBeforeReset = Logger.default();
+      Logger.reset();
     });
 
     afterEach(() => {
-      if (originalLevel === undefined) {
-        delete process.env.LOG_LEVEL;
-      } else {
-        process.env.LOG_LEVEL = originalLevel;
-      }
+      Logger.setDefault(instanceBeforeReset);
     });
 
-    it('uses LOG_LEVEL from environment', () => {
-      logger.info('msg');
-      expect(console.info).not.toHaveBeenCalled();
-      logger.warn('msg');
-      expect(console.warn).toHaveBeenCalledWith('msg');
+    it('causes default() to return a new ConsoleLogger instance', () => {
+      const newInstance = Logger.default();
+      expect(newInstance).toBeInstanceOf(ConsoleLogger);
+      expect(newInstance).not.toBe(instanceBeforeReset);
+    });
+  });
+
+  describe('.setDefault', () => {
+    let originalInstance;
+    let customLogger;
+
+    beforeEach(() => {
+      originalInstance = Logger.default();
+      customLogger = new ConsoleLogger('debug');
+      Logger.setDefault(customLogger);
+    });
+
+    afterEach(() => {
+      Logger.setDefault(originalInstance);
+    });
+
+    it('sets the instance returned by default()', () => {
+      expect(Logger.default()).toBe(customLogger);
     });
   });
 });
+

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -1580,13 +1580,6 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-express-rate-limit@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.3.2.tgz#81bbdbf599b7889a5b3cc272ec115aff200011be"
-  integrity sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==
-  dependencies:
-    ip-address "10.1.0"
-
 express@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
@@ -2055,11 +2048,6 @@ invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
-
-ip-address@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.1.0.tgz#d8dcffb34d0e02eb241427444a6e23f5b0595aa4"
-  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
 
 ipaddr.js@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
`Logger` only supported instance-based usage, requiring explicit instantiation before logging. This refactors the logger into a three-class hierarchy and adds static convenience methods that delegate to a lazily-created singleton, enabling direct class-level calls. Utility methods for suppressing log output, managing the singleton, and changing the log level at runtime are also included — all useful for test isolation and dynamic configuration.

## Architecture

The logger is now split into three focused classes:

- **`BaseLogger`** — all instance-level logic: level filtering (`#shouldLog`), `suppress`, `setLevel`, and the `_output(level, message)` template method (no-op base). Reads `LOG_LEVEL` env var in the constructor.
- **`ConsoleLogger extends BaseLogger`** — single override: `_output(level, message)` routes to `console[level](message)`.
- **`Logger`** — static-only facade; `default()` lazily creates/returns a `ConsoleLogger` singleton; all static methods delegate to it.

## Changes

- **`BaseLogger.js`** *(new)*
  - `#level`, `#suppressed`, `#levels` — private instance fields
  - `debug/info/warn/error(message)` — check `#shouldLog` then call `_output(level, message)`
  - `_output(level, message)` — no-op template method; override in subclasses
  - `suppress(value = true)` — silences all output for that instance when `true`; call `suppress(false)` to re-enable
  - `setLevel(level)` — changes the log level threshold at runtime; throws for unrecognised values

- **`ConsoleLogger.js`** *(new)*
  - Extends `BaseLogger`
  - `_output(level, message)` → `console[level](message)`

- **`Logger.js`** *(static facade only)*
  - `static #defaultInstance` — private field holding the singleton
  - `static default()` — lazy initializer returning the singleton `ConsoleLogger`
  - `static debug/info/warn/error(message)` — each delegates to `this.default().<method>(message)`
  - `static suppress(value = true)` — delegates to the default singleton instance
  - `static setLevel(level)` — delegates to the default singleton instance
  - `static reset()` — resets the default instance to `null` so a fresh one is created on the next call to `default()`
  - `static setDefault(newLogger)` — sets the default instance to the provided logger, enabling mock/spy injection in tests

- **`Worker.js`** — updated to use `new ConsoleLogger()` directly

- **`BaseLogger_spec.js`** *(new)*
  - Level-filtering tests (all five levels) using `_output` spies — no console dependency
  - `LOG_LEVEL` env var test
  - Tests for `suppress` (default no-arg call and toggle back with `false`)
  - Tests for `setLevel` (lower, raise, invalid value throws)

- **`ConsoleLogger_spec.js`** *(new)*
  - Tests that `_output` routes each level to the correct `console.*` method

- **`Logger_spec.js`** *(updated)*
  - Singleton identity test (`Logger.default() === Logger.default()`)
  - `toBeInstanceOf(ConsoleLogger)` checks for `default()` and after `reset()`
  - Delegation tests for all four static log methods
  - Delegation tests for static `suppress`, `setLevel`, `reset`, `setDefault`

## Usage

```javascript
// Static shorthand via singleton
Logger.info('msg');
Logger.warn('something is off');

// Suppressing logs (e.g. in tests)
Logger.suppress();          // silences the default instance
Logger.suppress(false);     // restores it

const logger = new ConsoleLogger();
logger.suppress();          // silences this specific instance
logger.suppress(false);     // restores it

// Changing the log level at runtime
Logger.setLevel('debug');   // enable debug on the default logger
Logger.setLevel('warn');    // quiet things down again

const logger = new ConsoleLogger();
logger.setLevel('error');   // raise level on a specific instance

// Injecting a mock logger in tests
const mockLogger = jasmine.createSpyObj('Logger', ['debug', 'info', 'warn', 'error']);
Logger.setDefault(mockLogger);
// ... test code ...
Logger.reset();             // restore to fresh singleton afterwards
```

All existing behaviour is preserved. The default instance respects `process.env.LOG_LEVEL` as before.

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

## Objetivo

Adicionar métodos estáticos à classe `Logger` que deleguem para uma instância default, permitindo uso mais conveniente sem necessidade de instanciar explicitamente.

## Arquivo a Modificar

**Arquivo:** `source/lib/utils/Logger.js`

## Mudanças Necessárias

### 1. Adicionar campo estático privado para armazenar a instância default

```javascript
static #defaultInstance;
```

### 2. Adicionar método estático `default()` que retorna a instância singleton

```javascript
/**
 * Returns the default Logger instance (singleton).
 * @returns {Logger} The default logger instance.
 */
static default() {
  if (!this.#defaultInstance) {
    this.#defaultInstance = new Logger();
  }
  return this.#defaultInstance;
}
```

### 3. Adicionar métodos estáticos que delegam para a instância default

Adicionar os seguintes métodos estáticos:

```javascript
/**
 * Logs a debug message using the default logger instance.
 * @param {string} message - The message to log.
 * @returns {void}
 */
static debug(message) {
  return this.default().debug(message);
}

/**
 * Logs an info message using the default logger instance.
 * @param {string} message - The message to log.
 * @returns {void}
 */
static info(message) {
  return this.default().info(message);
}

/**
 * Logs a warn message using the default logger instance.
 * @param {string} message - The message to log.
 * @returns {void}
 */
static warn(message) {
  return this.default().warn(message);
}

/**
 * Logs an error message using the default logger instance.
 * @param {string} message - The message to log.
 * @returns {void}
 */
static error(message) {
  return this.default().error(message);
}
```

## Comportamento Esperado

Após as mudanças, o Logger poderá ser usado de duas formas:

**Forma 1 - Método estático (novo):**
```javascript
Logger.debug('Debug message');
Logger.info('Info message');
Logger.warn('Warning message');
Logger.error('Error message');
```

**Forma 2 - Instância explícita (mantida):**
```javascript
const logger = new Logger('debug');
logger.debug('Debug message');
logger.info('Info message');
```

## Vantagens

1. **Conveniência:** Permite usar o Logger sem criar instância explicitamente
2. **Singleton:** A instância default é reutilizada (eficiência de memória)
3. **Retrocompatibilidade:** Código existente que cria instâncias continua funcionando
4. **Flexibilidade:** Ainda é possível criar instâncias personalizadas com diferentes níveis de log

## Notas

- Os métodos de instância existentes **não devem ser modificados**
- A instância default usa o nível de log padrão (baseado em `process.env.LOG_LEVEL` ou 'info')
- Não há conflito entre métodos estáticos e de instância com o mesmo nome em JavaScript


The following is the prior conversation context from the user's chat exploration (may be truncated):

User: Assim como adicionamos o método addMatcher ao Configuration, vamos adicionar o método addMiddleware que fará o build e anexará este middleware ao handler que está no rule 

Assistant: Vou primeiro examinar o arquivo Configuration.php para entender a estrutura atual e como o método `addMatcher` funciona:

Assistant: Agora vou verificar a classe `Rule` para entender como funciona o método `addMatcher` e ver se há um método correspondente para adicionar middleware ao handler:

Assistant: Agora vou verificar como o handler funciona para entender melhor como adicionar middlewares dinamicamente:

Assistant: Perfeito! Agora entendo a estrutura. Vou adicionar o método `addMiddleware` à classe `Configuration`, seguindo o mesmo padrão do método `addMatcher`. 

Baseado no código atual, vejo que:
1. O método `addMatcher` pega uma rule pelo nome e chama `addMatcher` nela
2. A Rule tem um `handlerConfig` que pode conter middlewares
3. No método `Rule::build()`, os middlewares são passados para o `handlerConfig` (linha 101)

Preciso criar um método `addMiddleware` na classe `Rule` e depois um método correspondente em `Configuration`. Vou verificar como os middlewares são gerenciados no handler:

Assistant: Perfeito! Agora entendo como funciona. Analisando o código, vejo que:

1. O método `addMatcher` no `Configuration` busca a regra pelo nome e chama `$rule->addMatcher($params['matcher'])`
2. O `Rule` tem o método `addMatcher` que constrói um matcher e adiciona ao array
3. Os middlewares são adicionados ao handler através de `buildMiddleware()` ou `buildMiddlewares()`
4. O handler tem métodos `addMiddleware()` e `buildMiddleware()` para anexar middlewares

Agora vou criar um método `addMiddleware` semelhante ao `addMatcher` na classe `Configuration`:

```php
/**
 * Adds a middleware to an existing rule identified by name.
 *
 * Locates the rule with the given name, builds the middleware, and adds it to the rule's handler.
 *
 * @example
 * ```php
 * Configuration::addMiddleware([
 *     'rule'       => 'api-persons',
 *     'middleware' => [
 *         'class' => 'Tent\\Middlewares\\SetHeadersMiddleware',
 *         'headers' => ['Host' => 'backend.lo...

</details>

