### PR TITLE
Add LoggerGroup for broadcasting log messages to multiple loggers

### DIFF
--- a/source/lib/utils/LoggerGroup.js
+++ b/source/lib/utils/LoggerGroup.js
@@ -1,0 +1,82 @@
+/**
+ * LoggerGroup broadcasts log messages to multiple Logger instances.
+ * Useful for sending the same log output to multiple destinations (console, web, file, etc.).
+ * @author darthjee
+ */
+class LoggerGroup {
+  #loggers;
+
+  /**
+   * Creates a new LoggerGroup instance.
+   * @param {Array<Logger>} [loggers=[]] - Array of Logger instances to broadcast to.
+   */
+  constructor(loggers = []) {
+    this.#loggers = loggers;
+  }
+
+  /**
+   * Adds a logger to the group.
+   * @param {Logger} logger - The Logger instance to add.
+   * @returns {LoggerGroup} This instance for method chaining.
+   */
+  addLogger(logger) {
+    this.#loggers.push(logger);
+    return this;
+  }
+
+  /**
+   * Removes a logger from the group.
+   * @param {Logger} logger - The Logger instance to remove.
+   * @returns {LoggerGroup} This instance for method chaining.
+   */
+  removeLogger(logger) {
+    this.#loggers = this.#loggers.filter(l => l !== logger);
+    return this;
+  }
+
+  /**
+   * Returns all loggers in the group.
+   * @returns {Array<Logger>} Array of Logger instances.
+   */
+  getLoggers() {
+    return [...this.#loggers];
+  }
+
+  /**
+   * Broadcasts a debug message to all loggers in the group.
+   * @param {string} message - The message to log.
+   * @returns {void}
+   */
+  debug(message) {
+    this.#loggers.forEach(logger => logger.debug(message));
+  }
+
+  /**
+   * Broadcasts an info message to all loggers in the group.
+   * @param {string} message - The message to log.
+   * @returns {void}
+   */
+  info(message) {
+    this.#loggers.forEach(logger => logger.info(message));
+  }
+
+  /**
+   * Broadcasts a warn message to all loggers in the group.
+   * @param {string} message - The message to log.
+   * @returns {void}
+   */
+  warn(message) {
+    this.#loggers.forEach(logger => logger.warn(message));
+  }
+
+  /**
+   * Broadcasts an error message to all loggers in the group.
+   * @param {string} message - The message to log.
+   * @returns {void}
+   */
+  error(message) {
+    this.#loggers.forEach(logger => logger.error(message));
+  }
+}
+
+export { LoggerGroup };

--- a/source/lib/utils/index.js
+++ b/source/lib/utils/index.js
@@ -1,0 +1,2 @@
+export { Logger } from './Logger.js';
+export { LoggerGroup } from './LoggerGroup.js';

--- a/source/spec/utils/LoggerGroup_spec.js
+++ b/source/spec/utils/LoggerGroup_spec.js
@@ -1,0 +1,134 @@
+/* eslint-disable no-console */
+import { LoggerGroup } from '../../lib/utils/LoggerGroup.js';
+
+describe('LoggerGroup', () => {
+  let loggerA;
+  let loggerB;
+
+  beforeEach(() => {
+    loggerA = {
+      debug: jasmine.createSpy('debug'),
+      info: jasmine.createSpy('info'),
+      warn: jasmine.createSpy('warn'),
+      error: jasmine.createSpy('error'),
+    };
+
+    loggerB = {
+      debug: jasmine.createSpy('debug'),
+      info: jasmine.createSpy('info'),
+      warn: jasmine.createSpy('warn'),
+      error: jasmine.createSpy('error'),
+    };
+  });
+
+  describe('constructor', () => {
+    it('creates an empty group when no arguments are provided', () => {
+      const group = new LoggerGroup();
+      expect(group.getLoggers()).toEqual([]);
+    });
+
+    it('creates a group with the provided loggers', () => {
+      const group = new LoggerGroup([loggerA, loggerB]);
+      expect(group.getLoggers()).toEqual([loggerA, loggerB]);
+    });
+  });
+
+  describe('#addLogger', () => {
+    it('adds a logger to the group', () => {
+      const group = new LoggerGroup();
+      group.addLogger(loggerA);
+      expect(group.getLoggers()).toEqual([loggerA]);
+    });
+
+    it('returns this for method chaining', () => {
+      const group = new LoggerGroup();
+      const result = group.addLogger(loggerA);
+      expect(result).toBe(group);
+    });
+  });
+
+  describe('#removeLogger', () => {
+    it('removes a logger from the group', () => {
+      const group = new LoggerGroup([loggerA, loggerB]);
+      group.removeLogger(loggerA);
+      expect(group.getLoggers()).toEqual([loggerB]);
+    });
+
+    it('returns this for method chaining', () => {
+      const group = new LoggerGroup([loggerA]);
+      const result = group.removeLogger(loggerA);
+      expect(result).toBe(group);
+    });
+
+    it('does not affect other loggers', () => {
+      const group = new LoggerGroup([loggerA, loggerB]);
+      group.removeLogger(loggerA);
+      expect(group.getLoggers()).toContain(loggerB);
+    });
+  });
+
+  describe('#getLoggers', () => {
+    it('returns a copy of the internal loggers array', () => {
+      const group = new LoggerGroup([loggerA]);
+      const loggers = group.getLoggers();
+      loggers.push(loggerB);
+      expect(group.getLoggers()).toEqual([loggerA]);
+    });
+  });
+
+  describe('#debug', () => {
+    it('calls debug on all loggers', () => {
+      const group = new LoggerGroup([loggerA, loggerB]);
+      group.debug('test message');
+      expect(loggerA.debug).toHaveBeenCalledWith('test message');
+      expect(loggerB.debug).toHaveBeenCalledWith('test message');
+    });
+
+    it('does not throw when group is empty', () => {
+      const group = new LoggerGroup();
+      expect(() => group.debug('msg')).not.toThrow();
+    });
+  });
+
+  describe('#info', () => {
+    it('calls info on all loggers', () => {
+      const group = new LoggerGroup([loggerA, loggerB]);
+      group.info('test message');
+      expect(loggerA.info).toHaveBeenCalledWith('test message');
+      expect(loggerB.info).toHaveBeenCalledWith('test message');
+    });
+
+    it('does not throw when group is empty', () => {
+      const group = new LoggerGroup();
+      expect(() => group.info('msg')).not.toThrow();
+    });
+  });
+
+  describe('#warn', () => {
+    it('calls warn on all loggers', () => {
+      const group = new LoggerGroup([loggerA, loggerB]);
+      group.warn('test message');
+      expect(loggerA.warn).toHaveBeenCalledWith('test message');
+      expect(loggerB.warn).toHaveBeenCalledWith('test message');
+    });
+
+    it('does not throw when group is empty', () => {
+      const group = new LoggerGroup();
+      expect(() => group.warn('msg')).not.toThrow();
+    });
+  });
+
+  describe('#error', () => {
+    it('calls error on all loggers', () => {
+      const group = new LoggerGroup([loggerA, loggerB]);
+      group.error('test message');
+      expect(loggerA.error).toHaveBeenCalledWith('test message');
+      expect(loggerB.error).toHaveBeenCalledWith('test message');
+    });
+
+    it('does not throw when group is empty', () => {
+      const group = new LoggerGroup();
+      expect(() => group.error('msg')).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Introduces `LoggerGroup`, a composite logger that broadcasts to multiple `Logger` instances simultaneously — groundwork for supporting multiple log destinations (console, web, file, etc.).

## Changes

- **`source/lib/utils/LoggerGroup.js`** — New class with:
  - Constructor accepting an optional initial array of loggers
  - `addLogger` / `removeLogger` with method chaining
  - `getLoggers()` returning a defensive copy
  - `debug` / `info` / `warn` / `error` broadcasting to all registered loggers

- **`source/lib/utils/index.js`** — New barrel export re-exporting `Logger` and `LoggerGroup`

- **`source/spec/utils/LoggerGroup_spec.js`** — 16 specs covering all methods, including empty-group safety and chaining

## Usage

```javascript
import { Logger, LoggerGroup } from './lib/utils/index.js';

const group = new LoggerGroup([new Logger('debug')]);
group.addLogger(webLogger); // future logger types

group.info('broadcast to all destinations');
group.error('all loggers receive this');
```

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

## Objetivo

Criar uma nova classe `LoggerGroup` que permite fazer broadcast de mensagens de log para múltiplos loggers simultaneamente.

## Contexto

No futuro, o projeto terá múltiplos tipos de loggers (console, web, etc.). A classe `LoggerGroup` permitirá enviar a mesma mensagem de log para todos os loggers registrados, facilitando o broadcast de logs.

## Arquivo a Criar

**Arquivo:** `source/lib/utils/LoggerGroup.js`

## Implementação da Classe LoggerGroup

```javascript
/**
 * LoggerGroup broadcasts log messages to multiple Logger instances.
 * Useful for sending the same log output to multiple destinations (console, web, file, etc.).
 * @author darthjee
 */
class LoggerGroup {
  #loggers;

  /**
   * Creates a new LoggerGroup instance.
   * @param {Array<Logger>} [loggers=[]] - Array of Logger instances to broadcast to.
   */
  constructor(loggers = []) {
    this.#loggers = loggers;
  }

  /**
   * Adds a logger to the group.
   * @param {Logger} logger - The Logger instance to add.
   * @returns {LoggerGroup} This instance for method chaining.
   */
  addLogger(logger) {
    this.#loggers.push(logger);
    return this;
  }

  /**
   * Removes a logger from the group.
   * @param {Logger} logger - The Logger instance to remove.
   * @returns {LoggerGroup} This instance for method chaining.
   */
  removeLogger(logger) {
    this.#loggers = this.#loggers.filter(l => l !== logger);
    return this;
  }

  /**
   * Returns all loggers in the group.
   * @returns {Array<Logger>} Array of Logger instances.
   */
  getLoggers() {
    return [...this.#loggers];
  }

  /**
   * Broadcasts a debug message to all loggers in the group.
   * @param {string} message - The message to log.
   * @returns {void}
   */
  debug(message) {
    this.#loggers.forEach(logger => logger.debug(message));
  }

  /**
   * Broadcasts an info message to all loggers in the group.
   * @param {string} message - The message to log.
   * @returns {void}
   */
  info(message) {
    this.#loggers.forEach(logger => logger.info(message));
  }

  /**
   * Broadcasts a warn message to all loggers in the group.
   * @param {string} message - The message to log.
   * @returns {void}
   */
  warn(message) {
    this.#loggers.forEach(logger => logger.warn(message));
  }

  /**
   * Broadcasts an error message to all loggers in the group.
   * @param {string} message - The message to log.
   * @returns {void}
   */
  error(message) {
    this.#loggers.forEach(logger => logger.error(message));
  }
}

export { LoggerGroup };
```

## Atualizar arquivo de exportação

**Arquivo:** `source/lib/utils/index.js`

Adicionar a exportação do LoggerGroup:

```javascript
export { LoggerGroup } from './LoggerGroup.js';
```

## Testes

Criar arquivo de testes para a classe LoggerGroup.

**Arquivo:** `source/spec/lib/utils/LoggerGroup.spec.js`

Criar testes que verifiquem:

1. **Construtor:**
   - Cria instância vazia sem parâmetros
   - Cria instância com array de loggers inicial

2. **addLogger:**
   - Adiciona logger ao grupo
   - Retorna this para method chaining

3. **removeLogger:**
   - Remove logger do grupo
   - Retorna this para method chaining
   - Não afeta outros loggers

4. **getLoggers:**
   - Retorna cópia do array de loggers
   - Não permite modificação direta do array interno

5. **Métodos de logging (debug, info, warn, error):**
   - Chama o método correspondente em todos os loggers
   - Funciona com múltiplos loggers
   - Funciona com grupo vazio (não gera erro)
   - Passa a mensagem corretamente para cada logger

## Exemplo de Uso

```javascript
import { Logger } from './utils/Logger.js';
import { LoggerGroup } from './utils/LoggerGroup.js';

// Criar loggers individuais
const consoleLogger = new Logger('debug');
const webLogger = new WebLogger(); // futuro logger web

// Criar grupo e adicionar loggers
const loggerGroup = new LoggerGroup([consoleLogger]);
loggerGroup.addLogger(webLogger);

// Broadcast para todos os loggers
loggerGroup.info('Esta mensagem vai para console e web');
loggerGroup.error('Erro transmitido para todos os destinos');
```

## Comportamento Esperado

1. A classe permite agrupar múltiplos loggers
2. Cada chamada de log é transmitida para todos os loggers do grupo
3. Suporta adicionar e remover loggers dinamicamente
4. Interface compatível com Logger (mesmos métodos de logging)
5. Permite method chaining nos métodos addLogger e removeLogger

## Benefícios

1. **Broadcast de logs:** Uma mensagem pode ir para múltiplos destinos
2. **Flexibilidade:** Adicionar/remover loggers em runtime
3. **Futuro-proof:** Facilita adicionar novos tipos de logger (web, arquivo, etc.)
4. **Interface consistente:** Mesmos métodos que Logger
5. **Composição:** Permite criar hierarquias complexas de logging


The following is the prior conversation context from the user's chat exploration (may be truncated):

User: Assim como adicionamos o método addMatcher ao Configuration, vamos adicionar o método addMiddleware que fará o build e anexa...

</details>

