### PR TITLE
refactor(dev/app): convert `_` private fields to `#` and enforce member order via ESLint

### DIFF
--- a/dev/app/eslint.config.mjs
+++ b/dev/app/eslint.config.mjs
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import importPlugin from 'eslint-plugin-import';
 import jasmine from 'eslint-plugin-jasmine';
+import sortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 
 export default [
@@ -12,6 +13,7 @@ export default [
     files: ['**/*.js'],
     plugins: {
       'import': importPlugin,
+      'sort-class-members': sortClassMembers,
     },
     languageOptions: {
       ecmaVersion: 'latest',
@@ -46,6 +48,18 @@ export default [
       eqeqeq: ['error', 'always'],
       'no-var': 'error',
       'prefer-const': 'error',
+
+      'sort-class-members/sort-class-members': ['error', {
+        order: [
+          '[static-properties]',
+          '[static-methods]',
+          '[properties]',
+          'constructor',
+          { type: 'method', private: false },
+          { type: 'method', private: true },
+        ],
+        accessorPairPositioning: 'getThenSet',
+      }],
     },
   },
   {

--- a/dev/app/lib/DataNavigator.js
+++ b/dev/app/lib/DataNavigator.js
@@ -3,13 +3,16 @@
  * Numeric steps perform an Array#find by `id`; string steps access an object key.
  */
 class DataNavigator {
+  #data;
+  #steps;
+
   /**
    * @param {Object|Array} data - Root data structure to navigate.
    * @param {Array<string|number>} steps - Ordered navigation steps.
    */
   constructor(data, steps) {
-    this._data = data;
-    this._steps = steps;
+    this.#data = data;
+    this.#steps = steps;
   }
 
   /**
@@ -18,9 +21,9 @@ class DataNavigator {
    * @returns {*}
    */
   navigate() {
-    let current = this._data;
+    let current = this.#data;
 
-    for (const step of this._steps) {
+    for (const step of this.#steps) {
       if (current === null || current === undefined) return null;
 
       if (typeof step === 'number') {

--- a/dev/app/lib/RequestHandler.js
+++ b/dev/app/lib/RequestHandler.js
@@ -7,15 +7,19 @@ import RouteParamsExtractor from './RouteParamsExtractor.js';
  * optionally serializing the result, and writing the JSON response.
  */
 class RequestHandler {
+  #route;
+  #data;
+  #serializer;
+
   /**
    * @param {string} route - Express route pattern used to derive navigation steps.
    * @param {Object} data - Root data structure.
    * @param {import('./Serializer.js').default|null} [serializer] - Optional serializer to project the result.
    */
   constructor(route, data, serializer = null) {
-    this._route = route;
-    this._data = data;
-    this._serializer = serializer;
+    this.#route = route;
+    this.#data = data;
+    this.#serializer = serializer;
   }
 
   /**
@@ -25,10 +29,10 @@ class RequestHandler {
    * @param {import('express').Response} res
    */
   handle(req, res) {
-    const steps = new RouteParamsExtractor(this._route, req.params).steps();
-    const result = new DataNavigator(this._data, steps).navigate();
+    const steps = new RouteParamsExtractor(this.#route, req.params).steps();
+    const result = new DataNavigator(this.#data, steps).navigate();
     if (result === null) return notFound(res);
-    res.json(this._serializer ? this._serializer.serialize(result) : result);
+    res.json(this.#serializer ? this.#serializer.serialize(result) : result);
   }
 }
 

--- a/dev/app/lib/RouteParamsExtractor.js
+++ b/dev/app/lib/RouteParamsExtractor.js
@@ -3,13 +3,16 @@
  * ordered steps array expected by {@link DataNavigator}.
  */
 class RouteParamsExtractor {
+  #route;
+  #params;
+
   /**
    * @param {string} route - Express route pattern (e.g. `/categories/:id.json`).
    * @param {Object<string, string>} params - Resolved route params from `req.params`.
    */
   constructor(route, params) {
-    this._route = route;
-    this._params = params;
+    this.#route = route;
+    this.#params = params;
   }
 
   /**
@@ -17,13 +20,13 @@ class RouteParamsExtractor {
    * @returns {Array<string|number>}
    */
   steps() {
-    return this._route
+    return this.#route
       .replace(/\.json$/, '')
       .split('/')
       .filter(Boolean)
       .map((segment) => {
         if (segment.startsWith(':')) {
-          return Number(this._params[segment.slice(1)]);
+          return Number(this.#params[segment.slice(1)]);
         }
         return segment;
       });

--- a/dev/app/lib/RouteRegister.js
+++ b/dev/app/lib/RouteRegister.js
@@ -6,13 +6,16 @@ import Serializer from './Serializer.js';
  * to a {@link RequestHandler} and an optional {@link Serializer}.
  */
 class RouteRegister {
+  #router;
+  #data;
+
   /**
    * @param {import('express').Router} router - Express router instance.
    * @param {Object} data - Root data structure shared across all handlers.
    */
   constructor(router, data) {
-    this._router = router;
-    this._data = data;
+    this.#router = router;
+    this.#data = data;
   }
 
   /**
@@ -23,8 +26,8 @@ class RouteRegister {
    */
   register({ route, attributes } = {}) {
     const serializer = attributes ? new Serializer(attributes) : null;
-    const handler = new RequestHandler(route, this._data, serializer);
-    this._router.get(route, (req, res) => handler.handle(req, res));
+    const handler = new RequestHandler(route, this.#data, serializer);
+    this.#router.get(route, (req, res) => handler.handle(req, res));
   }
 }
 

--- a/dev/app/lib/Router.js
+++ b/dev/app/lib/Router.js
@@ -6,11 +6,13 @@ import RouteRegister from './RouteRegister.js';
  * registered for the categories-and-items API.
  */
 class Router {
+  #data;
+
   /**
    * @param {Object} data - Parsed YAML data loaded at startup.
    */
   constructor(data) {
-    this._data = data;
+    this.#data = data;
   }
 
   /**
@@ -19,7 +21,7 @@ class Router {
    */
   build() {
     const router = ExpressRouter();
-    const register = new RouteRegister(router, this._data);
+    const register = new RouteRegister(router, this.#data);
 
     register.register({ route: '/categories.json', attributes: ['id', 'name'] });
     register.register({ route: '/categories/:id.json', attributes: ['id', 'name'] });

--- a/dev/app/lib/Serializer.js
+++ b/dev/app/lib/Serializer.js
@@ -3,11 +3,13 @@
  * stripping any fields not in the allowlist.
  */
 class Serializer {
+  #attributes;
+
   /**
    * @param {string[]} attributes - List of attribute names to keep in the output.
    */
   constructor(attributes) {
-    this._attributes = attributes;
+    this.#attributes = attributes;
   }
 
   /**
@@ -21,7 +23,7 @@ class Serializer {
       return data.map((item) => this.serialize(item));
     }
     return Object.fromEntries(
-      this._attributes.map((attr) => [attr, data[attr]])
+      this.#attributes.map((attr) => [attr, data[attr]])
     );
   }
 }

--- a/dev/app/package.json
+++ b/dev/app/package.json
@@ -15,16 +15,17 @@
   },
   "devDependencies": {
     "@eslint/js": "^8.0.0",
+    "c8": "11.0.0",
     "eslint": "^8.0.1",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jasmine": "^4.1.3",
     "eslint-plugin-n": "^15.3.0",
     "eslint-plugin-promise": "^6.0.1",
+    "eslint-plugin-sort-class-members": "1.22.1",
     "globals": "^16.5.0",
     "jasmine": "^5.0.0",
     "jscpd": "4.0.8",
-    "c8": "11.0.0",
     "supertest": "^7.0.0"
   },
   "jasmine": {
@@ -38,8 +39,13 @@
       "text",
       "html"
     ],
-    "extension": [".js"],
-    "include": ["app.js", "lib/**/*.js"],
+    "extension": [
+      ".js"
+    ],
+    "include": [
+      "app.js",
+      "lib/**/*.js"
+    ],
     "exclude": [
       "spec/**",
       "coverage/**",

--- a/dev/app/yarn.lock
+++ b/dev/app/yarn.lock
@@ -1009,6 +1009,11 @@ eslint-plugin-promise@^6.0.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz#acd3fd7d55cead7a10f92cf698f36c0aafcd717a"
   integrity sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==
 
+eslint-plugin-sort-class-members@1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.22.1.tgz#9f2f44a5530e86c53d7847ce825b75e81403dbce"
+  integrity sha512-TC76+m06fjpiAYPrEcyyvvWzp1aMHNBVGROLu9ijQuPDZPWJjhNTheha4f6f7eUTWabloczLZagoZ+mb6Cv0ZQ==
+
 eslint-scope@^7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"


### PR DESCRIPTION
Applies the CONTRIBUTING.md rule (public methods before private) to `dev/app/lib` by migrating all convention-based `_property` pseudo-privates to true ES2022 private fields (`#property`), and adds a lint rule to enforce the ordering automatically.

## Class changes (`dev/app/lib/`)

All six classes — `DataNavigator`, `Serializer`, `RouteParamsExtractor`, `RouteRegister`, `Router`, `RequestHandler` — now use explicit private field declarations:

```js
// Before
class DataNavigator {
  constructor(data, steps) {
    this._data = data;
    this._steps = steps;
  }
}

// After
class DataNavigator {
  #data;
  #steps;

  constructor(data, steps) {
    this.#data = data;
    this.#steps = steps;
  }
}
```

## ESLint rule (`dev/app/eslint.config.mjs`)

Added `eslint-plugin-sort-class-members` enforcing the order:
`[static-properties]` → `[static-methods]` → `[properties]` → `constructor` → public methods → private methods

Uses explicit `{ type: 'method', private: false }` / `{ type: 'method', private: true }` matchers rather than the `[methods]` built-in, which does not distinguish privacy for ordering purposes.
