### PR TITLE
feat(frontend): add ESLint rule enforcing public methods before private methods and CircleCI checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,17 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - checks-frontend:
+          filters:
+            tags:
+              only: /.*/
       - coverage-final:
           requires: [jasmine, jasmine-dev]
           filters:
             tags:
               only: /.*/
       - build-and-release:
-          requires: [jasmine, jasmine-dev, checks, checks-dev]
+          requires: [jasmine, jasmine-dev, checks, checks-dev, checks-frontend]
           filters:
             tags:
               only: /\d+\.\d+\.\d+/
@@ -98,6 +102,21 @@ jobs:
       - run:
           name: Duplication report (JSCPD)
           command: cd dev/app; npm run report
+
+  checks-frontend:
+    docker:
+      - image: darthjee/circleci_node:0.2.1
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: cd frontend; yarn install
+      - run:
+          name: Lint
+          command: cd frontend; npm run lint
+      - run:
+          name: Duplication report (JSCPD)
+          command: cd frontend; npm run report
 
   coverage-final:
     docker:

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,112 @@
+import js from '@eslint/js';
+import complexity from 'eslint-plugin-complexity';
+import importPlugin from 'eslint-plugin-import';
+import jasmine from 'eslint-plugin-jasmine';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import globals from 'globals';
+
+export default [
+  {
+    ignores: ['node_modules/**/*.js', 'dist/**/*.js', 'report/**'],
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.{js,jsx,mjs}'],
+    plugins: {
+      complexity,
+      react,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+      'import': importPlugin,
+    },
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2021,
+      },
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+      // recommended by eslint-plugin-import
+      'import/resolver': {
+        node: { extensions: ['.js', '.mjs', '.jsx'] },
+      },
+    },
+    rules: {
+      // Ensure import statements are alphabetized and grouped
+      'import/order': ['error', {
+        alphabetize: { order: 'asc', caseInsensitive: true },
+        'newlines-between': 'never',
+        groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index']],
+      }],
+
+      'no-trailing-spaces': ['error', { skipBlankLines: false, ignoreComments: false }],
+      'no-multi-spaces': ['error', { ignoreEOLComments: true }],
+
+      // Complexity rules
+      complexity: ['warn', { max: 10 }],
+      'max-lines': ['warn', { max: 300 }],
+      'max-depth': ['warn', { max: 4 }],
+
+      // Code style
+      indent: ['error', 2, { SwitchCase: 1 }],
+      'linebreak-style': ['error', 'unix'],
+      quotes: ['error', 'single', { avoidEscape: true }],
+      semi: ['error', 'always'],
+
+      // Best practices
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      eqeqeq: ['error', 'always'],
+      'no-var': 'error',
+      'prefer-const': 'error',
+
+      // Class member ordering: public methods must be declared before private methods
+      'no-restricted-syntax': ['error', {
+        selector: 'ClassBody > MethodDefinition[key.type="PrivateIdentifier"] ~ MethodDefinition:not([key.type="PrivateIdentifier"])',
+        message: 'Public methods must be declared before private methods.',
+      }],
+
+      // React rules
+      'react/jsx-uses-react': 'error',
+      'react/jsx-uses-vars': 'error',
+      'react/prop-types': 'off', // Disabled - project doesn't use PropTypes
+      'react/react-in-jsx-scope': 'off', // React 17+ doesn't need this
+
+      // React Hooks rules
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+
+      // React Refresh rules
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+  // Jasmine spec files configuration
+  {
+    files: ['spec/**/*_spec.js', 'spec/**/*[sS]pec.js'],
+    plugins: {
+      jasmine,
+    },
+    languageOptions: {
+      globals: {
+        ...globals.jasmine,
+      },
+    },
+    rules: {
+      'jasmine/no-focused-tests': 'error',
+      'jasmine/no-disabled-tests': 'warn',
+    },
+  },
+];

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
-import StatItem from './components/StatItem.jsx';
 import fetchStats from './clients/StatsClient.js';
+import StatItem from './components/StatItem.jsx';
 
 function App() {
   const [stats, setStats] = useState(null);
@@ -51,19 +51,19 @@ function App() {
       <section className="mb-5">
         <h2 className="h4 mb-3">Workers</h2>
         <div className="row row-cols-2 row-cols-md-4 g-3">
-          <StatItem label="Idle"  value={workers.idle} variant="success" />
-          <StatItem label="Busy"  value={workers.busy} variant="warning" />
+          <StatItem label="Idle" value={workers.idle} variant="success" />
+          <StatItem label="Busy" value={workers.busy} variant="warning" />
         </div>
       </section>
 
       <section>
         <h2 className="h4 mb-3">Jobs</h2>
         <div className="row row-cols-2 row-cols-md-5 g-3">
-          <StatItem label="Enqueued"   value={jobs.enqueued}   variant="secondary" />
-          <StatItem label="Processing" value={jobs.processing} variant="primary"   />
-          <StatItem label="Failed"     value={jobs.failed}     variant="danger"    />
-          <StatItem label="Finished"   value={jobs.finished}   variant="success"   />
-          <StatItem label="Dead"       value={jobs.dead}       variant="dark"      />
+          <StatItem label="Enqueued" value={jobs.enqueued} variant="secondary" />
+          <StatItem label="Processing" value={jobs.processing} variant="primary" />
+          <StatItem label="Failed" value={jobs.failed} variant="danger" />
+          <StatItem label="Finished" value={jobs.finished} variant="success" />
+          <StatItem label="Dead" value={jobs.dead} variant="dark" />
         </div>
       </section>
     </div>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   server: {


### PR DESCRIPTION
The `contributing.md` defines a convention that public methods must be declared before private (`#`-prefixed) methods in class bodies. This adds a corresponding ESLint rule to the frontend to enforce it statically, and adds a dedicated CircleCI job to run frontend checks on every push.

## Changes

- **`frontend/eslint.config.mjs`** *(new)* — Full ESLint flat config for the frontend, including code style, complexity, React/hooks, import ordering, and Jasmine spec rules. The key addition:

  ```js
  'no-restricted-syntax': ['error', {
    selector: 'ClassBody > MethodDefinition[key.type="PrivateIdentifier"] ~ MethodDefinition:not([key.type="PrivateIdentifier"])',
    message: 'Public methods must be declared before private methods.',
  }],
  ```

  This flags any public method that follows a private method in the same class body.

- **`frontend/src/App.jsx`** — Fixed import order and removed JSX prop alignment spaces (violations exposed by the new config).
- **`frontend/vite.config.js`** — Fixed import order (same reason).
- **`.circleci/config.yml`** — Added `checks-frontend` job (install deps → lint → JSCPD duplication report), following the same pattern as `checks` (source) and `checks-dev` (dev/app). Also added `checks-frontend` as a required dependency of `build-and-release`.


