### PR TITLE
fix: use `clientRegistry` instead of `clients` when initializing JobRegistry

### DIFF
--- a/source/lib/services/Application.js
+++ b/source/lib/services/Application.js
@@ -36,7 +36,7 @@ class Application {
   }
 
   #initRegistries({ jobRegistry, workersRegistry } = {}) {
-    this.jobRegistry = jobRegistry || new JobRegistry({ clients: this.config.clients });
+    this.jobRegistry = jobRegistry || new JobRegistry({ clients: this.config.clientRegistry });
     this.workersRegistry = workersRegistry || new WorkersRegistry({
       jobRegistry: this.jobRegistry,
       workers: this.#workers,

--- a/source/spec/services/Application_spec.js
+++ b/source/spec/services/Application_spec.js
@@ -1,6 +1,7 @@
 import { ConfigurationFileNotFound } from '../../lib/exceptions/ConfigurationFileNotFound.js';
 import { ConfigurationFileNotProvided } from '../../lib/exceptions/ConfigurationFileNotProvided.js';
 import { Config } from '../../lib/models/Config.js';
+import { ClientRegistry } from '../../lib/registry/ClientRegistry.js';
 import { JobRegistry } from '../../lib/registry/JobRegistry.js';
 import { WorkersRegistry } from '../../lib/registry/WorkersRegistry.js';
 import { WebServer } from '../../lib/server/WebServer.js';
@@ -45,6 +46,20 @@ describe('Application', () => {
         expect(app.jobRegistry instanceof JobRegistry).toBeTrue();
       });
 
+      it('initializes job registry with clientRegistry from config', () => {
+        app.loadConfig(configFilePath);
+
+        expect(app.jobRegistry instanceof JobRegistry).toBeTrue();
+        expect(app.config.clientRegistry instanceof ClientRegistry).toBeTrue();
+      });
+
+      it('does not expose a clients property on config (uses clientRegistry instead)', () => {
+        app.loadConfig(configFilePath);
+
+        expect(app.config.clients).toBeUndefined();
+        expect(app.config.clientRegistry).toBeDefined();
+      });
+
       it('initializes workers registry', () => {
         const workers = new IdentifyableCollection();
 
@@ -80,7 +95,7 @@ describe('Application', () => {
       config = Config.fromFile(configFilePath);
 
       jobFactory = new DummyJobFactory();
-      jobRegistry = new JobRegistry({ clients: config.clients, factory: jobFactory });
+      jobRegistry = new JobRegistry({ clients: config.clientRegistry, factory: jobFactory });
 
       workerFactory = new DummyWorkerFactory({ jobRegistry });
       workersRegistry = new WorkersRegistry({ quantity: 1, jobRegistry, factory: workerFactory });


### PR DESCRIPTION
`Application#initRegistries` was passing `this.config.clients` to `JobRegistry`, but `Config` stores clients under `clientRegistry` — making `clients` always `undefined` and leaving `JobFactory` without a valid client registry.

## Changes

- **`Application.js`**: `this.config.clients` → `this.config.clientRegistry` in `#initRegistries`
- **`Application_spec.js`**:
  - Fixed same typo in the `#run` test setup (`config.clients` → `config.clientRegistry`)
  - Added regression tests asserting `config.clientRegistry` is a `ClientRegistry` instance after `loadConfig`
  - Added guard test asserting `config.clients` is `undefined` (catches future regressions of this kind)

```js
// Before (bug)
this.jobRegistry = jobRegistry || new JobRegistry({ clients: this.config.clients });

// After
this.jobRegistry = jobRegistry || new JobRegistry({ clients: this.config.clientRegistry });
```