### PR TITLE
Add Logger.error to all try-catch blocks missing error logging

### DIFF
--- a/source/lib/models/Job.js
+++ b/source/lib/models/Job.js
@@ -1,3 +1,5 @@
+import { Logger } from '../utils/Logger.js';
+
 /**
  * Job represents a unit of work to be processed by a Worker.
  * @author darthjee
@@ -38,6 +40,7 @@ class Job {
       this.lastError = undefined;
       return await this.#getClient().perform(this.#resourceRequest);
     } catch (error) {
+      Logger.error(`Job #${this.id} failed: ${error}`);
       this._fail(error);
     }
   }

--- a/source/lib/services/Client.js
+++ b/source/lib/services/Client.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { RequestFailed } from '../exceptions/RequestFailed.js';
+import { Logger } from '../utils/Logger.js';
 
 /**
  * Client performs HTTP requests for resource paths using a configured base URL.
@@ -52,6 +53,7 @@ class Client {
     try {
       return await this.#request(resourceRequest);
     } catch (error) {
+      Logger.error(`Request failed: ${error}`);
       if (error.response) {
         throw new RequestFailed(error.response.status, this.#buildUrl(resourceRequest.url));
       }

--- a/source/lib/services/ConfigLoader.js
+++ b/source/lib/services/ConfigLoader.js
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import YAML from 'yaml';
 import { ConfigParser } from './ConfigParser.js';
 import { ConfigurationFileNotFound } from '../exceptions/ConfigurationFileNotFound.js';
+import { Logger } from '../utils/Logger.js';
 
 /**
  * ConfigLoader loads a YAML configuration file and delegates parsing to ConfigParser.
@@ -65,6 +66,7 @@ class ConfigLoader {
     try {
       return readFileSync(this.filePath, 'utf8');
     } catch (err) {
+      Logger.error(`Configuration file not found: ${this.filePath}`);
       throw new ConfigurationFileNotFound(this.filePath);
     }
   }

--- a/source/spec/models/Job_spec.js
+++ b/source/spec/models/Job_spec.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { RequestFailed } from '../../lib/exceptions/RequestFailed.js';
 import { Job } from '../../lib/models/Job.js';
+import { Logger } from '../../lib/utils/Logger.js';
 import { ClientFactory } from '../support/factories/ClientFactory.js';
 import { ClientRegistryFactory } from '../support/factories/ClientRegistryFactory.js';
 import { ResourceRequestFactory } from '../support/factories/ResourceRequestFactory.js';
@@ -74,6 +75,7 @@ describe('Job', () => {
         expectedError = new RequestFailed(502, fullUrl);
 
         spyOn(axios, 'get').and.returnValue(promise);
+        spyOn(Logger, 'error').and.stub();
       });
 
       it('register failure and attempt', async () => {
@@ -86,11 +88,17 @@ describe('Job', () => {
         expect(job.exhausted()).toBeTrue();
         expect(job.lastError).toEqual(expectedError);
       });
+
+      it('logs the error', async () => {
+        await job.perform().catch(() => {});
+        expect(Logger.error).toHaveBeenCalledWith(`Job #${job.id} failed: ${expectedError}`);
+      });
     });
   });
 
   describe('#exhausted', () => {
     beforeEach(async () => {
+      spyOn(Logger, 'error').and.stub();
       await job.perform().catch(() => {});
       await job.perform().catch(() => {});
     });

--- a/source/spec/services/Application_spec.js
+++ b/source/spec/services/Application_spec.js
@@ -7,6 +7,7 @@ import { WorkersRegistry } from '../../lib/registry/WorkersRegistry.js';
 import { WebServer } from '../../lib/server/WebServer.js';
 import { Application } from '../../lib/services/Application.js';
 import { IdentifyableCollection } from '../../lib/utils/IdentifyableCollection.js';
+import { Logger } from '../../lib/utils/Logger.js';
 import { DummyJobFactory } from '../support/dummies/factories/DummyJobFactory.js';
 import { DummyWorkerFactory } from '../support/dummies/factories/DummyWorkerFactory.js';
 import { DummyJob } from '../support/dummies/models/DummyJob.js';
@@ -75,6 +76,10 @@ describe('Application', () => {
     });
 
     describe('when config file is invalid', () => {
+      beforeEach(() => {
+        spyOn(Logger, 'error').and.stub();
+      });
+
       it('should throw an error', () => {
         expect(() => app.loadConfig('invalid')).toThrowError(ConfigurationFileNotFound);
       });

--- a/source/spec/services/Client_spec.js
+++ b/source/spec/services/Client_spec.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { Logger } from '../../lib/utils/Logger.js';
 import { ClientFactory } from '../support/factories/ClientFactory.js';
 import { ResourceRequestFactory } from '../support/factories/ResourceRequestFactory.js';
 
@@ -33,13 +34,16 @@ describe('Client', () => {
         statusCode: 404,
         url: fullUrl,
       });
+
+      spyOn(Logger, 'error').and.stub();
     });
 
-    it('throws RequestFailed when status does not match', async () => {
+    it('throws RequestFailed when status does not match and logs the error', async () => {
       const promise = Promise.resolve({ status: 404 });
       spyOn(axios, 'get').and.returnValue(promise);
 
       await expectAsync(client.perform(resourceRequest)).toBeRejectedWith(expectedError);
+      expect(Logger.error).toHaveBeenCalled();
     });
   });
 
@@ -64,13 +68,16 @@ describe('Client', () => {
         statusCode: 500,
         url: fullUrl,
       });
+
+      spyOn(Logger, 'error').and.stub();
     });
 
-    it('throws RequestFailed with correct status and full url on error.response', async () => {
+    it('throws RequestFailed with correct status and full url on error.response and logs the error', async () => {
       const promise = Promise.reject({ response: { status: 500 } });
       spyOn(axios, 'get').and.returnValue(promise);
 
       await expectAsync(client.perform(resourceRequest)).toBeRejectedWith(expectedError);
+      expect(Logger.error).toHaveBeenCalled();
     });
   });
 });

--- a/source/spec/services/ConfigLoader_spec.js
+++ b/source/spec/services/ConfigLoader_spec.js
@@ -1,6 +1,7 @@
 import { ConfigurationFileNotFound } from '../../lib/exceptions/ConfigurationFileNotFound.js';
 import { WorkersConfig } from '../../lib/models/WorkersConfig.js';
 import { ConfigLoader } from '../../lib/services/ConfigLoader.js';
+import { Logger } from '../../lib/utils/Logger.js';
 import { ClientFactory } from '../support/factories/ClientFactory.js';
 import { ResourceFactory } from '../support/factories/ResourceFactory.js';
 import { FixturesUtils } from '../support/utils/FixturesUtils.js';
@@ -90,12 +91,17 @@ describe('ConfigLoader', () => {
     });
 
     describe('when the file is not found', () => {
-      it('throws an error', () => {
+      beforeEach(() => {
+        spyOn(Logger, 'error').and.stub();
+      });
+
+      it('throws an error and logs it', () => {
         const configFilePath = FixturesUtils.getFixturePath('non-existing.yml');
 
         expect(() => ConfigLoader.fromFile(configFilePath)).toThrowError(
           ConfigurationFileNotFound
         );
+        expect(Logger.error).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
Several `try-catch` blocks in the application were silently swallowing or re-throwing errors without logging them via `Logger.error`.

## Source changes

- **`Job.js`** — logs `Job #${id} failed: ${error}` before delegating to `_fail(error)`
- **`ConfigLoader.js`** — logs `Configuration file not found: ${filePath}` before re-throwing `ConfigurationFileNotFound`
- **`Client.js`** — logs `Request failed: ${error}` before re-throwing (either as `RequestFailed` or the original error)

```js
// Example: Client.js perform()
} catch (error) {
  Logger.error(`Request failed: ${error}`);
  if (error.response) {
    throw new RequestFailed(error.response.status, this.#buildUrl(resourceRequest.url));
  }
  throw error;
}
```

## Test changes

- Added `spyOn(Logger, 'error')` in failure contexts for `Job_spec`, `Client_spec`, and `ConfigLoader_spec`, with assertions that `Logger.error` is called
- Added spy in `Application_spec` and `Job#exhausted` contexts to suppress incidental console output from real HTTP failures
