### PR TITLE
Add `clientName` getter to `ResourceRequest` derived from `Resource.client`

### DIFF
--- a/source/lib/models/Resource.js
+++ b/source/lib/models/Resource.js
@@ -9,10 +9,12 @@ class Resource {
    * Represents a resource with a name and associated resource requests.
    * @param {object} params - The parameters for creating a Resource instance.
    * @param {string} params.name - The name of the resource.
+   * @param {string} [params.client] - The name of the client to use for requests from this resource.
    * @param {Array} params.resourceRequests - The resource requests associated with the resource.
    */
-  constructor({ name, resourceRequests }) {
+  constructor({ name, client, resourceRequests }) {
     this.name = name;
+    this.client = client;
     this.resourceRequests = resourceRequests;
   }
 
@@ -20,6 +22,7 @@ class Resource {
    * Creates a Resource instance from a plain object.
    * @param {object} obj - The plain object representing a resource.
    * @param {string} obj.name - The name of the resource.
+   * @param {string} [obj.client] - The name of the client to use for requests from this resource.
    * @param {Array<{url: string, status: number}>} obj.resourceRequests -
    * The resource requests associated with the resource.
    * @returns {Resource} A new Resource instance.
@@ -27,7 +30,8 @@ class Resource {
   static fromObject(obj) {
     return new Resource({
       name: obj.name,
-      resourceRequests: ResourceRequest.fromList(obj.resourceRequests)
+      client: obj.client,
+      resourceRequests: ResourceRequest.fromList(obj.resourceRequests, { clientName: obj.client })
     });
   }
 

--- a/source/lib/models/ResourceRequest.js
+++ b/source/lib/models/ResourceRequest.js
@@ -3,14 +3,27 @@
  * @author darthjee
  */
 class ResourceRequest {
+  #clientName;
+
   /**
-   * @param {{ url: string, status: number }} attributes ResourceRequest attributes
+   * @param {{ url: string, status: number, clientName: string }} attributes ResourceRequest attributes
    * @param {string} attributes.url The URL to request.
    * @param {number} attributes.status The expected status code of the response.
+   * @param {string} [attributes.clientName] The name of the client to use for this request.
    */
-  constructor({ url, status }) {
+  constructor({ url, status, clientName }) {
     this.url = url;
     this.status = status;
+    this.#clientName = clientName;
+  }
+
+  /**
+   * Returns the name of the client associated with this request,
+   * as inherited from the parent Resource's client attribute.
+   * @returns {string|undefined} The client name, or undefined if not set.
+   */
+  get clientName() {
+    return this.#clientName;
   }
 
   /**
@@ -25,10 +38,12 @@ class ResourceRequest {
   /**
    * Creates a list of ResourceRequest instances from an array of objects.
    * @param {Array<{ url: string, status: number }>} array list of objects with attributes to create a new ResourceRequest
+   * @param {object} [options={}] optional options to assign to each ResourceRequest
+   * @param {string} [options.clientName] optional client name to assign to each ResourceRequest
    * @returns {Array<ResourceRequest>} list of ResourceRequest instances
    */
-  static fromList(array) {
-    return array.map((resource) => new ResourceRequest(resource));
+  static fromList(array, { clientName } = {}) {
+    return array.map((attrs) => new ResourceRequest({ ...attrs, clientName }));
   }
 }
 

--- a/source/spec/models/ResourceRequest_spec.js
+++ b/source/spec/models/ResourceRequest_spec.js
@@ -17,6 +17,29 @@ describe('ResourceRequest', () => {
       ]);
       expect(resourceRequests.every((resourceRequest) => resourceRequest instanceof ResourceRequest)).toBeTrue();
     });
+
+    it('assigns the given clientName to each ResourceRequest', () => {
+      const resources = [
+        { url: '/categories.json', status: 200 },
+        { url: '/categories.html', status: 302 },
+      ];
+
+      const resourceRequests = ResourceRequest.fromList(resources, { clientName: 'myClient' });
+
+      expect(resourceRequests.every((rr) => rr.clientName === 'myClient')).toBeTrue();
+    });
+  });
+
+  describe('#clientName', () => {
+    it('returns undefined when no clientName is set', () => {
+      const request = ResourceRequestFactory.build();
+      expect(request.clientName).toBeUndefined();
+    });
+
+    it('returns the clientName when set', () => {
+      const request = ResourceRequestFactory.build({ clientName: 'myClient' });
+      expect(request.clientName).toBe('myClient');
+    });
   });
 
   describe('#needsParams', () => {

--- a/source/spec/models/Resource_spec.js
+++ b/source/spec/models/Resource_spec.js
@@ -27,6 +27,13 @@ describe('Resource', () => {
         ],
       }));
     });
+
+    it('propagates the client name to each ResourceRequest', () => {
+      const resource = Resource.fromObject({ name, client: 'myClient', resourceRequests });
+
+      expect(resource.client).toBe('myClient');
+      expect(resource.resourceRequests.every((rr) => rr.clientName === 'myClient')).toBeTrue();
+    });
   });
 
   describe('.fromListObject', () => {

--- a/source/spec/support/factories/ResourceFactory.js
+++ b/source/spec/support/factories/ResourceFactory.js
@@ -9,11 +9,12 @@ class ResourceFactory {
    * Builds a Resource instance.
    * @param {object} [params={}] - Optional attributes.
    * @param {string} [params.name='categories'] - The resource name.
+   * @param {string} [params.client] - The name of the client to use for requests.
    * @param {Array} [params.resourceRequests] - List of ResourceRequest instances. Defaults to one default ResourceRequestFactory.build().
    * @returns {Resource} A new Resource instance.
    */
-  static build({ name = 'categories', resourceRequests = [ResourceRequestFactory.build()] } = {}) {
-    return new Resource({ name, resourceRequests });
+  static build({ name = 'categories', client = undefined, resourceRequests = [ResourceRequestFactory.build()] } = {}) {
+    return new Resource({ name, client, resourceRequests });
   }
 }
 

--- a/source/spec/support/factories/ResourceRequestFactory.js
+++ b/source/spec/support/factories/ResourceRequestFactory.js
@@ -9,10 +9,11 @@ class ResourceRequestFactory {
    * @param {object} [params={}] - Optional attributes.
    * @param {string} [params.url='/categories.json'] - The URL template.
    * @param {number} [params.status=200] - The expected HTTP status code.
+   * @param {string} [params.clientName] - The name of the client to use for this request.
    * @returns {ResourceRequest} A new ResourceRequest instance.
    */
-  static build({ url = '/categories.json', status = 200 } = {}) {
-    return new ResourceRequest({ url, status });
+  static build({ url = '/categories.json', status = 200, clientName = undefined } = {}) {
+    return new ResourceRequest({ url, status, clientName });
   }
 }
 


### PR DESCRIPTION
`Job#getClient()` called `this.#resourceRequest.clientName`, but `ResourceRequest` had no such property — the client concept existed only implicitly via `Resource`.

## Changes

- **`ResourceRequest`**: Added private `#clientName` field, updated constructor to accept optional `clientName`, and exposed it via `get clientName()`.
- **`ResourceRequest.fromList(array, clientName?)`**: Accepts an optional `clientName` and forwards it to each constructed instance.
- **`Resource`**: Added `client` property; `fromObject()` now reads `obj.client` and propagates it through `fromList()`, so all child `ResourceRequest`s inherit the resource-level client name.
- **Factories & specs**: Updated `ResourceRequestFactory` and `ResourceFactory` to accept the new optional params; added coverage for `clientName` getter and `Resource → ResourceRequest` propagation.

```js
// Resource with a named client
const resource = Resource.fromObject({
  name: 'categories',
  client: 'myClient',
  resourceRequests: [{ url: '/categories.json', status: 200 }],
});

resource.client;                               // 'myClient'
resource.resourceRequests[0].clientName;       // 'myClient'

// Job#getClient() now resolves the correct client
job.perform(); // calls clients.getClient('myClient')
```
