### PR TITLE
Enforce private-after-public method ordering in source via lint rule

### DIFF
--- a/source/eslint.config.mjs
+++ b/source/eslint.config.mjs
@@ -5,6 +5,7 @@ import jasmine from 'eslint-plugin-jasmine';
 import jsdoc from 'eslint-plugin-jsdoc';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import sortClassMembers from 'eslint-plugin-sort-class-members';
 import globals from 'globals';
 
 export default [
@@ -20,6 +21,7 @@ export default [
       'react-hooks': reactHooks,
       jsdoc,
       'import': importPlugin,
+      'sort-class-members': sortClassMembers,
     },
     languageOptions: {
       ecmaVersion: 'latest',
@@ -73,6 +75,18 @@ export default [
       eqeqeq: ['error', 'always'],
       'no-var': 'error',
       'prefer-const': 'error',
+
+      'sort-class-members/sort-class-members': ['error', {
+        order: [
+          '[static-properties]',
+          '[static-methods]',
+          '[properties]',
+          'constructor',
+          { type: 'method', private: false },
+          { type: 'method', private: true },
+        ],
+        accessorPairPositioning: 'getThenSet',
+      }],
 
       // React rules
       'react/jsx-uses-react': 'error',

--- a/source/lib/registry/NamedRegistry.js
+++ b/source/lib/registry/NamedRegistry.js
@@ -7,8 +7,6 @@ import { ItemNotFound } from '../exceptions/ItemNotFound.js';
  * @author darthjee
  */
 class NamedRegistry {
-  #size;
-
   /*
    * The exception class to throw when an item is not found.
    * Subclasses should override this property to specify the appropriate exception type.
@@ -17,6 +15,8 @@ class NamedRegistry {
    * @type {class}
    */
   static notFoundException = ItemNotFound;
+
+  #size;
 
   /**
    * @param {object} items An object mapping item names to their corresponding instances.

--- a/source/lib/services/Application.js
+++ b/source/lib/services/Application.js
@@ -35,17 +35,6 @@ class Application {
     this.#initRegistries(...options);
   }
 
-  #initRegistries({ jobRegistry, workersRegistry } = {}) {
-    this.jobRegistry = jobRegistry || new JobRegistry({ clients: this.config.clientRegistry });
-    this.workersRegistry = workersRegistry || new WorkersRegistry({
-      jobRegistry: this.jobRegistry,
-      workers: this.#workers,
-      ...this.config.workersConfig
-    });
-
-    this.workersRegistry.initWorkers();
-  }
-
   /**
    * Starts the application by building the engine, web server, enqueueing initial jobs, and starting both.
    * @returns {void}
@@ -91,6 +80,17 @@ class Application {
     new ResourceRequestCollector(this.config.resourceRegistry).requestsNeedingNoParams().forEach((resourceRequest) => {
       this.jobRegistry.enqueue({ resourceRequest, parameters: {} });
     });
+  }
+
+  #initRegistries({ jobRegistry, workersRegistry } = {}) {
+    this.jobRegistry = jobRegistry || new JobRegistry({ clients: this.config.clientRegistry });
+    this.workersRegistry = workersRegistry || new WorkersRegistry({
+      jobRegistry: this.jobRegistry,
+      workers: this.#workers,
+      ...this.config.workersConfig
+    });
+
+    this.workersRegistry.initWorkers();
   }
 }
 

--- a/source/lib/utils/BaseLogger.js
+++ b/source/lib/utils/BaseLogger.js
@@ -17,14 +17,6 @@ class BaseLogger {
   }
 
   /**
-   * @param {string} level - The log level to check.
-   * @returns {boolean} True if the message should be logged at the given level.
-   */
-  #shouldLog(level) {
-    return !this.#suppressed && this.#levels[level] >= this.#levels[this.#level];
-  }
-
-  /**
    * Outputs a message at the given level. Override in subclasses.
    * @param {string} _level - The log level.
    * @param {string} _message - The message to output.
@@ -87,6 +79,14 @@ class BaseLogger {
       throw new Error(`Invalid log level: "${level}". Must be one of: ${Object.keys(this.#levels).join(', ')}.`);
     }
     this.#level = level;
+  }
+
+  /**
+   * @param {string} level - The log level to check.
+   * @returns {boolean} True if the message should be logged at the given level.
+   */
+  #shouldLog(level) {
+    return !this.#suppressed && this.#levels[level] >= this.#levels[this.#level];
   }
 }
 

--- a/source/package.json
+++ b/source/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "eslint-plugin-sort-class-members": "1.22.1",
     "globals": "^16.5.0",
     "jasmine": "^5.0.0",
     "jscpd": "4.0.8",

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -1427,6 +1427,11 @@ eslint-plugin-react@^7.37.5:
     string.prototype.matchall "^4.0.12"
     string.prototype.repeat "^1.0.0"
 
+eslint-plugin-sort-class-members@1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.22.1.tgz#9f2f44a5530e86c53d7847ce825b75e81403dbce"
+  integrity sha512-TC76+m06fjpiAYPrEcyyvvWzp1aMHNBVGROLu9ijQuPDZPWJjhNTheha4f6f7eUTWabloczLZagoZ+mb6Cv0ZQ==
+
 eslint-scope@^7.2.2:
   version "7.2.2"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz"


### PR DESCRIPTION
Extends the `sort-class-members` ESLint rule (already active in `dev/app/`) to `source/`, enforcing that private methods (`#`) are always declared after public methods within a class body.

## Lint config (`source/eslint.config.mjs`)
- Added `eslint-plugin-sort-class-members` import and plugin registration
- Added `sort-class-members/sort-class-members` rule with order: static properties → static methods → properties → constructor → public methods → private methods

## Source fixes
Three files violated the new rule:

- **`NamedRegistry.js`** – moved `static notFoundException` before private field `#size`
- **`Application.js`** – moved `#initRegistries` after `loadConfig`, `run`, `buildEngine`, `buildWebServer`, `enqueueFirstJobs`
- **`BaseLogger.js`** – moved `#shouldLog` after all public methods (`_output`, `debug`, `info`, `warn`, `error`, `suppress`, `setLevel`)

## Dependency (`source/package.json`)
- Added `eslint-plugin-sort-class-members@1.22.1` (matches `dev/app/` version)
