### PR TITLE
Add missing JSDoc documentation in source/lib

### DIFF
--- a/source/lib/models/ActionEnqueuer.js
+++ b/source/lib/models/ActionEnqueuer.js
@@ -19,6 +19,7 @@ class ActionEnqueuer {
 
   /**
    * Enqueues one ActionProcessingJob per item for the configured action.
+   * @returns {void}
    */
   enqueue() {
     for (const item of this.#items) {

--- a/source/lib/models/ActionsEnqueuer.js
+++ b/source/lib/models/ActionsEnqueuer.js
@@ -25,6 +25,7 @@ class ActionsEnqueuer {
   /**
    * Normalises the parsed response to an array and enqueues one ActionProcessingJob
    * per (action × item) pair, delegating per-action item enqueueing to ActionEnqueuer.
+   * @returns {void}
    * @throws {NullResponse} If the parsed response is null.
    */
   enqueue() {

--- a/source/lib/models/ActionsExecutor.js
+++ b/source/lib/models/ActionsExecutor.js
@@ -28,6 +28,7 @@ class ActionsExecutor {
 
   /**
    * Normalises the parsed response to an array and dispatches each action per item.
+   * @returns {void}
    * @throws {NullResponse} If the parsed response is null.
    */
   execute() {

--- a/source/lib/models/Job.js
+++ b/source/lib/models/Job.js
@@ -39,6 +39,7 @@ class Job {
    * Sets the cooldown duration in milliseconds after which the job is eligible for retry.
    * Stores the absolute timestamp (Date.now() + ms) internally.
    * @param {number} ms - Cooldown duration in milliseconds. Use a negative value to mark ready immediately.
+   * @returns {void}
    */
   applyCooldown(ms) {
     this.#readyBy = Date.now() + ms;
@@ -73,6 +74,7 @@ class Job {
   /**
    * Handles a failed job attempt.
    * @param {Error} error - The error that caused the job to fail.
+   * @throws {Error} Re-throws the error after recording the failure.
    * @protected
    */
   _fail(error) {

--- a/source/lib/models/ResourceRequest.js
+++ b/source/lib/models/ResourceRequest.js
@@ -37,6 +37,7 @@ class ResourceRequest {
    * Enqueues one ActionProcessingJob per action associated with the resource request.
    * Returns immediately if there are no actions, skipping JSON parsing entirely.
    * @param {string} rawBody The raw response body string.
+   * @returns {void}
    */
   enqueueActions(rawBody) {
     if (this.actions.length === 0) return;
@@ -49,6 +50,7 @@ class ResourceRequest {
    * Executes all configured actions against the raw response body.
    * Returns immediately if there are no actions, skipping JSON parsing entirely.
    * @param {string} rawBody The raw response body string.
+   * @returns {void}
    */
   executeActions(rawBody) {
     if (this.actions.length === 0) return;

--- a/source/lib/models/ResourceRequestAction.js
+++ b/source/lib/models/ResourceRequestAction.js
@@ -31,6 +31,7 @@ class ResourceRequestAction {
   /**
    * Applies the variables_map to the response item and logs the result.
    * @param {object} item A single parsed response item.
+   * @returns {void}
    */
   execute(item) {
     const vars = this.#mapper.map(item);

--- a/source/lib/models/WorkersConfig.js
+++ b/source/lib/models/WorkersConfig.js
@@ -1,5 +1,6 @@
 /**
  * Represents the configuration for workers in the application.
+ * @author darthjee
  */
 class WorkersConfig {
   /**

--- a/source/lib/registry/JobRegistry.js
+++ b/source/lib/registry/JobRegistry.js
@@ -100,6 +100,11 @@ class JobRegistry {
     return JobRegistry.#getInstance().stats();
   }
 
+  /**
+   * Returns the singleton instance, throwing if not yet built.
+   * @returns {JobRegistryInstance} The singleton instance.
+   * @throws {Error} If `build()` has not been called.
+   */
   static #getInstance() {
     if (!JobRegistry.#instance) {
       throw new Error('JobRegistry has not been built. Call JobRegistry.build() first.');

--- a/source/lib/registry/ResourceRegistry.js
+++ b/source/lib/registry/ResourceRegistry.js
@@ -1,6 +1,11 @@
 import { NamedRegistry } from './NamedRegistry.js';
 import { ResourceNotFound } from '../exceptions/ResourceNotFound.js';
 
+/**
+ * Registry of named Resource instances.
+ * @author darthjee
+ * @augments NamedRegistry
+ */
 class ResourceRegistry extends NamedRegistry {
   /**
    * The exception class to throw when a resource is not found.

--- a/source/lib/registry/WorkersRegistry.js
+++ b/source/lib/registry/WorkersRegistry.js
@@ -90,6 +90,11 @@ class WorkersRegistry {
     return WorkersRegistry.#getInstance().stats();
   }
 
+  /**
+   * Returns the singleton instance, throwing if not yet built.
+   * @returns {WorkersRegistryInstance} The singleton instance.
+   * @throws {Error} If `build()` has not been called.
+   */
   static #getInstance() {
     if (!WorkersRegistry.#instance) {
       throw new Error('WorkersRegistry has not been built. Call WorkersRegistry.build() first.');

--- a/source/lib/registry/WorkersRegistryInstance.js
+++ b/source/lib/registry/WorkersRegistryInstance.js
@@ -51,6 +51,7 @@ class WorkersRegistryInstance {
   /**
    * Sets a worker as busy.
    * @param {string} worker_id - The ID of the worker to set as busy.
+   * @returns {void}
    */
   setBusy(worker_id) {
     const worker = this.#workers.get(worker_id);
@@ -64,6 +65,7 @@ class WorkersRegistryInstance {
   /**
    * Sets a worker as idle.
    * @param {string} worker_id - The ID of the worker to set as idle.
+   * @returns {void}
    */
   setIdle(worker_id) {
     const worker = this.#workers.get(worker_id);

--- a/source/lib/server/RequestHandler.js
+++ b/source/lib/server/RequestHandler.js
@@ -7,6 +7,7 @@ class RequestHandler {
    * Handles an incoming HTTP request.
    * @param {object} _req - The Express request object.
    * @param {object} _res - The Express response object.
+   * @returns {void}
    */
   handle(_req, _res) {}
 }

--- a/source/lib/server/RouteRegister.js
+++ b/source/lib/server/RouteRegister.js
@@ -17,6 +17,7 @@ class RouteRegister {
    * @param {object} params - Options for registering a route.
    * @param {string} params.route - The route path (e.g. '/stats.json').
    * @param {object} params.handler - The handler whose handle method is called.
+   * @returns {void}
    */
   register({ route, handler }) {
     this.#router.get(route, (req, res) => handler.handle(req, res));

--- a/source/lib/server/StatsRequestHandler.js
+++ b/source/lib/server/StatsRequestHandler.js
@@ -18,6 +18,7 @@ class StatsRequestHandler extends RequestHandler {
    * Responds with combined job and worker stats.
    * @param {object} _req - The Express request object.
    * @param {object} res - The Express response object.
+   * @returns {void}
    */
   handle(_req, res) {
     res.json({

--- a/source/lib/services/Application.js
+++ b/source/lib/services/Application.js
@@ -8,6 +8,11 @@ import { WorkersRegistry } from '../registry/WorkersRegistry.js';
 import { WebServer } from '../server/WebServer.js';
 import { ResourceRequestCollector } from '../utils/ResourceRequestCollector.js';
 
+/**
+ * Application orchestrates the startup of Navi by loading configuration,
+ * building registries, and running the Engine loop together with the WebServer.
+ * @author darthjee
+ */
 class Application {
   #workers;
 
@@ -79,6 +84,10 @@ class Application {
     });
   }
 
+  /**
+   * Initializes the job factory, job registry, and workers registry from the loaded configuration.
+   * @returns {void}
+   */
   #initRegistries() {
     JobFactory.build('ResourceRequestJob', { attributes: { clients: this.config.clientRegistry } });
     JobFactory.build('Action', { klass: ActionProcessingJob });

--- a/source/lib/services/ConfigParser.js
+++ b/source/lib/services/ConfigParser.js
@@ -59,10 +59,18 @@ class ConfigParser {
     };
   }
 
+  /**
+   * Creates a WorkersConfig from the parsed YAML workers section.
+   * @returns {WorkersConfig} The workers configuration instance.
+   */
   #workersConfig() {
     return new WorkersConfig(this.config.workers);
   }
 
+  /**
+   * Creates a WebConfig from the parsed YAML web section, or null if absent.
+   * @returns {WebConfig|null} The web configuration instance or null.
+   */
   #webConfig() {
     if (!this.config.web) return null;
     return new WebConfig(this.config.web);

--- a/source/lib/utils/collections/IdentifyableCollection.js
+++ b/source/lib/utils/collections/IdentifyableCollection.js
@@ -1,5 +1,9 @@
 import { Collection } from './Collection.js';
 
+/**
+ * An identifiable collection that stores items keyed by their id property.
+ * @author darthjee
+ */
 class IdentifyableCollection extends Collection {
   #items;
   #size = null;
@@ -15,6 +19,7 @@ class IdentifyableCollection extends Collection {
   /**
    * Adds an item to the collection.
    * @param {object} item - The item to add, must have a unique id.
+   * @returns {void}
    */
   push(item) {
     this.#size = null;
@@ -24,6 +29,7 @@ class IdentifyableCollection extends Collection {
   /**
    * Removes an item from the collection by id.
    * @param {string|number} id - The id of the item to remove.
+   * @returns {void}
    */
   remove(id) {
     this.#size = null;

--- a/source/lib/utils/collections/SortedArrayMerger.js
+++ b/source/lib/utils/collections/SortedArrayMerger.js
@@ -51,6 +51,10 @@ class SortedArrayMerger {
     return this.#result.concat(this.#first.slice(this.#i), this.#second.slice(this.#j));
   }
 
+  /**
+   * Picks the next element from the first or second array based on sort order.
+   * @returns {void}
+   */
   #pickNext() {
     if (this.#firstComesFirst()) {
       this.#result.push(this.#first[this.#i++]);
@@ -59,10 +63,19 @@ class SortedArrayMerger {
     }
   }
 
+  /**
+   * Checks whether both arrays still have unprocessed elements.
+   * @returns {boolean} True if both pointers are within bounds.
+   */
   #bothHaveMore() {
     return this.#i < this.#first.length && this.#j < this.#second.length;
   }
 
+  /**
+   * Determines whether the current element of the first array should come before
+   * the current element of the second array.
+   * @returns {boolean} True if the first element comes first.
+   */
   #firstComesFirst() {
     return this.#sortBy(this.#first[this.#i]) <= this.#sortBy(this.#second[this.#j]);
   }

--- a/source/lib/utils/collections/SortedArraySearcher.js
+++ b/source/lib/utils/collections/SortedArraySearcher.js
@@ -65,6 +65,10 @@ class SortedArraySearcher {
     return this.#lo;
   }
 
+  /**
+   * Performs one binary search step, narrowing the search range.
+   * @returns {void}
+   */
   #step() {
     if (this.#shouldAdvanceLo()) {
       this.#lo = this.#mid + 1;
@@ -73,6 +77,10 @@ class SortedArraySearcher {
     }
   }
 
+  /**
+   * Determines whether the lower bound should advance past the midpoint.
+   * @returns {boolean} True if the lower bound should be moved forward.
+   */
   #shouldAdvanceLo() {
     const item = this.#array[this.#mid];
     const sortedValue = this.#sortBy(item);
@@ -81,6 +89,10 @@ class SortedArraySearcher {
     return this.#isExclusiveMode();
   }
 
+  /**
+   * Checks whether the current mode is exclusive ('after' or 'upTo').
+   * @returns {boolean} True if the mode is exclusive.
+   */
   #isExclusiveMode() {
     return this.#mode === 'after' || this.#mode === 'upTo';
   }

--- a/source/lib/utils/collections/SortedCollection.js
+++ b/source/lib/utils/collections/SortedCollection.js
@@ -36,6 +36,7 @@ class SortedCollection extends Collection {
   /**
    * Adds an element to the pending (non-sorted) list.
    * @param {*} item - The element to add.
+   * @returns {void}
    */
   push(item) {
     this.#nonSorted.push(item);
@@ -112,11 +113,19 @@ class SortedCollection extends Collection {
     return this.#sorted.slice(0, i);
   }
 
+  /**
+   * Flushes pending elements and returns the sorted array.
+   * @returns {Array} The internal sorted array.
+   */
   #flushedSorted() {
     this.#flush();
     return this.#sorted;
   }
 
+  /**
+   * Merges pending elements into the sorted array if any are buffered.
+   * @returns {void}
+   */
   #flush() {
     if (this.#nonSorted.length === 0) return;
 
@@ -125,6 +134,10 @@ class SortedCollection extends Collection {
     this.#nonSorted = [];
   }
 
+  /**
+   * Sorts the pending non-sorted array in place using the sortBy function.
+   * @returns {void}
+   */
   #sortNonSorted() {
     this.#nonSorted.sort((a, b) => {
       const va = this.#sortBy(a);
@@ -133,10 +146,20 @@ class SortedCollection extends Collection {
     });
   }
 
+  /**
+   * Merges the sorted and non-sorted arrays using a two-pointer algorithm.
+   * @returns {Array} The merged sorted array.
+   */
   #merge() {
     return SortedArrayMerger.merge(this.#sorted, this.#nonSorted, this.#sortBy);
   }
 
+  /**
+   * Performs a binary search on the flushed sorted array.
+   * @param {*} value - The boundary value to search for.
+   * @param {'after'|'from'|'before'|'upTo'} mode - The range mode.
+   * @returns {number} The boundary index.
+   */
   #binarySearch(value, mode) {
     return SortedArraySearcher.search(this.#flushedSorted(), this.#sortBy, value, mode);
   }


### PR DESCRIPTION
Fills in missing JSDoc across `source/lib/` — primarily `@returns` tags on void methods, class-level doc blocks, and undocumented private methods.

### `@returns` tags added to void methods
- **models/**: `ResourceRequest.enqueueActions`, `executeActions`; `Job.applyCooldown`; `ActionEnqueuer.enqueue`; `ResourceRequestAction.execute`; `ActionsEnqueuer.enqueue`; `ActionsExecutor.execute`
- **registry/**: `WorkersRegistryInstance.setBusy`, `setIdle`
- **server/**: `RequestHandler.handle`, `RouteRegister.register`, `StatsRequestHandler.handle`
- **utils/**: `IdentifyableCollection.push`, `remove`; `SortedCollection.push`

### `@throws` added
- `Job._fail` — documents the re-throw behavior

### Missing class-level JSDoc
- `WorkersConfig`, `Application`, `IdentifyableCollection`, `ResourceRegistry`

### Private method JSDoc blocks
- **services/**: `Application.#initRegistries`, `ConfigParser.#workersConfig`, `#webConfig`
- **collections/**: `SortedArrayMerger.#pickNext`, `#bothHaveMore`, `#firstComesFirst`; `SortedArraySearcher.#step`, `#shouldAdvanceLo`, `#isExclusiveMode`; `SortedCollection.#flushedSorted`, `#flush`, `#sortNonSorted`, `#merge`, `#binarySearch`
- **registry/**: `JobRegistry.#getInstance`, `WorkersRegistry.#getInstance`

Documentation-only — 20 files changed, no functional code modified.