### PR TITLE
Add client headers support with env var interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ clients:
   auth_api:
     base_url: https://api.example.com
     headers:
-      Authorization: Bearer <token>
+      Authorization: Bearer $API_TOKEN
+      X-Custom-Header: static-value
 
 resources:
   categories:
@@ -94,7 +95,7 @@ resources:
 | `workers.retry_cooldown` | Milliseconds a failed job waits before being re-queued for retry. Defaults to `2000`. |
 | `web.port` | Port for the local monitoring web UI. Omit the `web` key entirely to run Navi without the web server. |
 | `clients.<name>.base_url` | Base URL for the named HTTP client. |
-| `clients.<name>.headers` | Optional HTTP headers sent with every request of this client. |
+| `clients.<name>.headers` | Optional HTTP headers sent with every request of this client. Header values support environment variable references (`$VAR` or `${VAR}`), which are resolved at configuration load time. |
 | `resources.<name>` | A named group of URL requests to warm. |
 | `url` | URL path (appended to the client's `base_url`). Supports `{:placeholder}` tokens. |
 | `status` | Expected HTTP response status code. Navi marks a request as failed if the actual status differs. |

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -114,6 +114,7 @@ ID generation utilities.
 
 | Class | Responsibility |
 |-------|---------------|
+| `EnvResolver` | Resolves environment variable references (`$VAR` / `${VAR}`) in string values. Used by `Client.fromObject()` to interpolate header values at parse time. |
 | `ResourceRequestCollector` | Iterates a `ResourceRegistry` and enqueues one job per resource+parameter combination. |
 
 ### `services/`
@@ -126,7 +127,7 @@ Business logic and I/O layer.
 | `ArgumentsParser` | Parses CLI arguments using Node's `parseArgs`. Supports `--config <path>` / `-c <path>`; defaults to `config/navi_config.yml`. Returns `{ config }`. |
 | `ConfigLoader` | File I/O — reads YAML from disk using `fs.readFileSync` and the `yaml` library. |
 | `ConfigParser` | Converts the parsed YAML object into model instances (validates required keys, builds registries). |
-| `Client` | HTTP executor using Axios. `perform(resourceRequest, params)` fetches a URL with `responseType: 'text'` and throws `RequestFailed` if the status does not match. |
+| `Client` | HTTP executor using Axios. `perform(resourceRequest, params)` fetches a URL with `responseType: 'text'` and throws `RequestFailed` if the status does not match. Supports per-client headers (including environment variable interpolation via `$VAR` / `${VAR}` syntax, resolved at parse time). |
 | `Engine` | Drives the main allocation loop. Each tick calls `JobRegistry.promoteReadyJobs()` then delegates to `WorkersAllocator.allocate()` while jobs or busy workers exist. Sleeps for `sleepMs` (default 500 ms) when all pending jobs are in cooldown. |
 | `WorkersAllocator` | Assigns ready jobs to idle workers. On each `allocate()` call, repeatedly pairs `WorkersRegistry.getIdleWorker()` with `JobRegistry.pick()` until either pool is exhausted. |
 | `JobFactory` | Static registry of named job factories. `JobFactory.build(name, options)` registers a factory; `JobFactory.get(name)` retrieves it; `JobFactory.reset()` clears all entries (test teardown). |

--- a/docs/agents/flow.md
+++ b/docs/agents/flow.md
@@ -55,7 +55,7 @@ It instantiates `Application`, calls `loadConfig(configPath)`, and then calls `r
    Throws `ConfigurationFileNotProvided` if `configPath` is falsy.
    Throws `ConfigurationFileNotFound` if the file does not exist.
 2. `ConfigParser` validates required top-level keys and builds:
-   - `ClientRegistry` — named HTTP client definitions (`base_url`, optional headers/auth).
+   - `ClientRegistry` — named HTTP client definitions (`base_url`, optional `headers` with env var interpolation).
    - `ResourceRegistry` — named resource groups, each containing one or more `ResourceRequest` entries.
    - `WorkersConfig` — worker pool size (`workers.quantity`, default 1) and `retryCooldown`.
    - `WebConfig` — web server port (`web.port`); `null` when the `web:` key is absent.

--- a/docs/agents/issues/195_client_configuration_does_not_support_headers_as_described_in_readme.md
+++ b/docs/agents/issues/195_client_configuration_does_not_support_headers_as_described_in_readme.md
@@ -1,0 +1,33 @@
+# Issue: Client Configuration Does Not Support Headers as Described in README
+
+## Description
+
+The README documents that the client configuration accepts headers, but the current implementation does not allow headers to be passed as an argument. This discrepancy is misleading and limits the flexibility of the client configuration.
+
+## Problem
+
+- The client configuration does not accept a `headers` argument despite the README implying it does.
+- Users cannot pass custom headers through client configuration.
+- Environment variables cannot be used as header values, reducing configurability.
+- The mismatch between documentation and implementation misleads users.
+
+## Expected Behavior
+
+- The client configuration should accept a `headers` argument.
+- Header values should support environment variable references, allowing runtime customization based on the running environment.
+
+## Solution
+
+1. Update the client configuration implementation to accept a `headers` argument.
+2. Ensure headers can be provided directly as static values or resolved from environment variables.
+3. Update the README with a realistic usage example reflecting the new behavior.
+4. Add tests to verify that headers (including those derived from environment variables) are correctly handled.
+
+## Benefits
+
+- Aligns implementation with documented behavior, eliminating user confusion.
+- Enables advanced integration scenarios that require custom request headers (e.g., authentication tokens, API keys).
+- Makes header configuration more flexible by supporting environment variable interpolation.
+
+---
+See issue for details: https://github.com/darthjee/navi/issues/195

--- a/docs/agents/plans/195_client_configuration_does_not_support_headers_as_described_in_readme/plan.md
+++ b/docs/agents/plans/195_client_configuration_does_not_support_headers_as_described_in_readme/plan.md
@@ -1,0 +1,64 @@
+# Plan: Client Configuration Does Not Support Headers as Described in README
+
+## Overview
+
+Add `headers` support to the client configuration so that custom HTTP headers can be passed per-client via YAML config. Header values must support environment variable references for runtime flexibility. Update all relevant documentation to reflect the new behavior.
+
+## Context
+
+The README implies that the client configuration accepts `headers`, but the current implementation ignores them. The `Client` service performs HTTP requests via Axios without forwarding any configured headers. This plan introduces headers at the config/model level, wires them through to the HTTP request, and aligns the docs.
+
+## Implementation Steps
+
+### Step 1 — Add headers to the client model
+
+Create or update the model that represents a named client's configuration (likely a `ClientConfig` class in `source/lib/models/`) to hold a `headers` map.
+
+- Add a `headers` field (default: `{}`).
+- Support environment variable interpolation for header values: if a value matches `$ENV_VAR_NAME` or `${ENV_VAR_NAME}`, resolve it from `process.env` at parse time.
+- Expose a static `fromObject()` factory method following existing model conventions.
+
+### Step 2 — Update ConfigParser to read headers from YAML
+
+In `source/lib/services/ConfigParser.js`, extend the client-parsing logic to read the `headers` key from each client entry and pass it to the client model factory.
+
+### Step 3 — Update Client service to forward headers
+
+In `source/lib/services/Client.js`, update the `perform(resourceRequest, params)` method (or its Axios call) to merge the client's configured headers into every request.
+
+### Step 4 — Add tests
+
+Add or update specs for:
+- The client model: headers are stored, static values pass through, env var references are resolved.
+- `ConfigParser`: headers from YAML are parsed and forwarded to the model.
+- `Client`: configured headers are included in outgoing requests.
+
+Spec files follow the `source/spec/lib/<mirror-path>/<ClassName>_spec.js` naming convention.
+
+### Step 5 — Update README
+
+Update the README to include a realistic YAML example showing the `headers` field, including an env-var-backed header value.
+
+### Step 6 — Update agent documentation
+
+Update the relevant files under `docs/agents/` to reflect the new capability:
+- `docs/agents/architecture.md` — update the `Client` and any client model descriptions.
+- `docs/agents/flow.md` — if headers resolution is described as part of the config-loading flow, update accordingly.
+
+## Files to Change
+
+- `source/lib/models/ClientConfig.js` (new or existing) — add `headers` field with env var interpolation
+- `source/lib/services/ConfigParser.js` — parse `headers` from YAML client entries
+- `source/lib/services/Client.js` — forward configured headers to Axios requests
+- `source/spec/lib/models/ClientConfig_spec.js` (new or existing) — unit tests for headers
+- `source/spec/lib/services/ConfigParser_spec.js` — test headers parsing
+- `source/spec/lib/services/Client_spec.js` — test headers forwarding
+- `README.md` — add `headers` YAML example
+- `docs/agents/architecture.md` — update `Client` and client model descriptions
+- `docs/agents/flow.md` — update config-loading flow if applicable
+
+## Notes
+
+- Environment variable resolution should happen at parse time (when the YAML is loaded), not at request time, to keep `Client.perform()` side-effect free.
+- If a referenced env var is not set, decide whether to throw a descriptive error or silently omit the header — this should be confirmed before implementation.
+- Existing client config entries without `headers` must continue to work (backward-compatible default of `{}`).

--- a/source/lib/services/Client.js
+++ b/source/lib/services/Client.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { RequestFailed } from '../exceptions/RequestFailed.js';
+import { EnvResolver } from '../utils/EnvResolver.js';
 import { Logger } from '../utils/logging/Logger.js';
 
 /**
@@ -15,11 +16,13 @@ class Client {
    * @param {string} attributes.name Name identifying this client.
    * @param {string} attributes.baseUrl Base URL used to build full request URLs.
    * @param {number} [attributes.timeout] Optional request timeout in milliseconds.
+   * @param {object} [attributes.headers] Optional HTTP headers sent with every request.
    */
-  constructor({ name, baseUrl, timeout = 5000 }) {
+  constructor({ name, baseUrl, timeout = 5000, headers = {} }) {
     this.name = name;
     this.baseUrl = baseUrl;
     this.timeout = timeout;
+    this.headers = headers;
   }
 
   /**
@@ -29,10 +32,13 @@ class Client {
    * @param {object} config Client configuration object.
    * @param {string} config.base_url Base URL for the client.
    * @param {number} [config.timeout] Optional request timeout in milliseconds.
+   * @param {object} [config.headers] Optional HTTP headers. Values matching
+   *   `$VAR` or `${VAR}` are resolved from `process.env` at parse time.
    * @returns {Client} A new Client instance.
    */
   static fromObject(name, config) {
-    return new Client({ name, baseUrl: config.base_url, timeout: config.timeout });
+    const headers = EnvResolver.resolveObject(config.headers || {});
+    return new Client({ name, baseUrl: config.base_url, timeout: config.timeout, headers });
   }
 
   /**
@@ -75,7 +81,11 @@ class Client {
    * @throws {RequestFailed} Throws an error if the response status does not match.
    */
   async #request(resourceRequest, requestUrl) {
-    const response = await axios.get(requestUrl, { timeout: this.timeout, responseType: 'text' });
+    const response = await axios.get(requestUrl, {
+      timeout: this.timeout,
+      responseType: 'text',
+      headers: this.headers,
+    });
 
     if (response.status !== resourceRequest.status) {
       throw new RequestFailed(response.status, requestUrl);

--- a/source/lib/utils/EnvResolver.js
+++ b/source/lib/utils/EnvResolver.js
@@ -1,0 +1,53 @@
+import { Logger } from './logging/Logger.js';
+
+/**
+ * Pattern matching environment variable references in strings.
+ * Supports `$VAR_NAME` and `${VAR_NAME}` syntax.
+ * @type {RegExp}
+ */
+const ENV_VAR_PATTERN = /\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+
+/**
+ * Resolves environment variable references in string values.
+ *
+ * Supports `$VAR_NAME` and `${VAR_NAME}` syntax, resolved from
+ * `process.env` at call time. Logs a warning when a referenced
+ * variable is not defined and replaces it with an empty string.
+ *
+ * @author darthjee
+ */
+class EnvResolver {
+  /**
+   * Resolves environment variable references in all values of an object.
+   *
+   * @param {object} object Map of keys to raw string values.
+   * @returns {object} A new object with env var references resolved in values.
+   */
+  static resolveObject(object) {
+    return Object.fromEntries(
+      Object.entries(object).map(([key, value]) => [key, EnvResolver.resolveValue(value)])
+    );
+  }
+
+  /**
+   * Resolves environment variable references in a single string value.
+   *
+   * @param {string} value Raw string value.
+   * @returns {string} Resolved value with env var references replaced.
+   */
+  static resolveValue(value) {
+    return String(value).replace(ENV_VAR_PATTERN, (_match, braced, bare) => {
+      const varName = braced || bare;
+      const resolved = process.env[varName];
+
+      if (resolved === undefined) {
+        Logger.warn(`Environment variable not defined: ${varName}`);
+        return '';
+      }
+
+      return resolved;
+    });
+  }
+}
+
+export { EnvResolver };

--- a/source/spec/lib/models/ResourceRequestJob_spec.js
+++ b/source/spec/lib/models/ResourceRequestJob_spec.js
@@ -47,7 +47,7 @@ describe('ResourceRequestJob', () => {
 
       it('resolves with the response', async () => {
         await expectAsync(job.perform()).toBeResolvedTo(response);
-        expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text' });
+        expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text', headers: {} });
       });
 
       it('calls enqueueActions with the response data', async () => {

--- a/source/spec/lib/models/Worker_spec.js
+++ b/source/spec/lib/models/Worker_spec.js
@@ -100,7 +100,7 @@ describe('Worker', () => {
         expect(job.exhausted()).toBeFalse();
         expect(job.lastError).toBeUndefined();
         await worker.perform();
-        expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text' });
+        expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text', headers: {} });
         expect(job.exhausted()).toBeFalse();
         expect(job.lastError).toBeUndefined();
         expect(console.error).not.toHaveBeenCalled();
@@ -133,7 +133,7 @@ describe('Worker', () => {
         expect(job.exhausted()).toBeFalse();
         expect(job.lastError).toBeUndefined();
         await worker.perform();
-        expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text' });
+        expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text', headers: {} });
         expect(job.exhausted()).toBeFalse();
         expect(job.lastError).toEqual(expectedError);
         expect(console.error).toHaveBeenCalledWith(`Error occurred while performing job: #${job.id} - ${expectedError}`);

--- a/source/spec/lib/services/Client_spec.js
+++ b/source/spec/lib/services/Client_spec.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { Client } from '../../../lib/services/Client.js';
 import { Logger } from '../../../lib/utils/logging/Logger.js';
 import { ClientFactory } from '../../support/factories/ClientFactory.js';
 import { ResourceRequestFactory } from '../../support/factories/ResourceRequestFactory.js';
@@ -25,7 +26,7 @@ describe('Client', () => {
     spyOn(Logger, 'info').and.stub();
 
     await expectAsync(client.perform(resourceRequest)).toBeResolvedTo(response);
-    expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text' });
+    expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text', headers: {} });
     expect(Logger.info).toHaveBeenCalledWith(`[Client:default] Requesting ${fullUrl}`);
   });
 
@@ -97,7 +98,74 @@ describe('Client', () => {
       spyOn(axios, 'get').and.returnValue(Promise.resolve(response));
 
       await expectAsync(client.perform(resourceRequest)).toBeResolvedTo(response);
-      expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text' });
+      expect(axios.get).toHaveBeenCalledWith(fullUrl, { timeout: 5000, responseType: 'text', headers: {} });
+    });
+  });
+
+  describe('when headers are configured', () => {
+    const headers = { Authorization: 'Bearer token123', 'X-Custom': 'value' };
+
+    beforeEach(() => {
+      client = ClientFactory.build({ baseUrl, headers });
+      spyOn(Logger, 'info').and.stub();
+    });
+
+    it('passes the headers to the axios request', async () => {
+      const response = { status: 200 };
+      spyOn(axios, 'get').and.returnValue(Promise.resolve(response));
+
+      await expectAsync(client.perform(resourceRequest)).toBeResolvedTo(response);
+      expect(axios.get).toHaveBeenCalledWith(fullUrl, {
+        timeout: 5000,
+        responseType: 'text',
+        headers: { Authorization: 'Bearer token123', 'X-Custom': 'value' },
+      });
+    });
+  });
+
+  describe('.fromObject', () => {
+    describe('when headers are provided', () => {
+      it('creates a client with the configured headers', () => {
+        const config = {
+          base_url: 'https://api.example.com',
+          headers: { 'X-Api-Key': 'abc123' },
+        };
+
+        const result = Client.fromObject('api', config);
+
+        expect(result.headers).toEqual({ 'X-Api-Key': 'abc123' });
+      });
+    });
+
+    describe('when headers are not provided', () => {
+      it('creates a client with empty headers', () => {
+        const config = { base_url: 'https://example.com' };
+
+        const result = Client.fromObject('default', config);
+
+        expect(result.headers).toEqual({});
+      });
+    });
+
+    describe('when header values reference environment variables', () => {
+      beforeEach(() => {
+        process.env.NAVI_TEST_TOKEN = 'secret-token-value';
+      });
+
+      afterEach(() => {
+        delete process.env.NAVI_TEST_TOKEN;
+      });
+
+      it('resolves env var references via EnvResolver', () => {
+        const config = {
+          base_url: 'https://example.com',
+          headers: { 'X-Token': '$NAVI_TEST_TOKEN' },
+        };
+
+        const result = Client.fromObject('api', config);
+
+        expect(result.headers).toEqual({ 'X-Token': 'secret-token-value' });
+      });
     });
   });
 });

--- a/source/spec/lib/services/ConfigParser_spec.js
+++ b/source/spec/lib/services/ConfigParser_spec.js
@@ -166,5 +166,26 @@ describe('ConfigParser', () => {
         expect(result.webConfig).toBeNull();
       });
     });
+
+    describe('when client config includes headers', () => {
+      beforeEach(() => {
+        config = FixturesUtils.loadYamlFixture('config/sample_config_with_headers.yml');
+      });
+
+      it('returns clients with parsed headers', () => {
+        const result = ConfigParser.fromObject(config);
+
+        expect(result.clients.auth_api.headers).toEqual({
+          Authorization: 'Bearer my-token',
+          'X-Custom-Header': 'custom-value',
+        });
+      });
+
+      it('returns a client without headers as empty object', () => {
+        const result = ConfigParser.fromObject(config);
+
+        expect(result.clients.default.headers).toEqual({});
+      });
+    });
   });
 });

--- a/source/spec/lib/utils/EnvResolver_spec.js
+++ b/source/spec/lib/utils/EnvResolver_spec.js
@@ -1,0 +1,119 @@
+import { EnvResolver } from '../../../lib/utils/EnvResolver.js';
+import { Logger } from '../../../lib/utils/logging/Logger.js';
+
+describe('EnvResolver', () => {
+  describe('.resolveValue', () => {
+    describe('when value has no env var references', () => {
+      it('returns the value unchanged', () => {
+        expect(EnvResolver.resolveValue('static-value')).toEqual('static-value');
+      });
+    });
+
+    describe('when value references an env var with $VAR syntax', () => {
+      beforeEach(() => {
+        process.env.NAVI_TEST_TOKEN = 'secret-token-value';
+      });
+
+      afterEach(() => {
+        delete process.env.NAVI_TEST_TOKEN;
+      });
+
+      it('resolves the variable from process.env', () => {
+        expect(EnvResolver.resolveValue('Bearer $NAVI_TEST_TOKEN'))
+          .toEqual('Bearer secret-token-value');
+      });
+    });
+
+    describe('when value references an env var with ${VAR} syntax', () => {
+      beforeEach(() => {
+        process.env.NAVI_TEST_TOKEN = 'secret-token-value';
+      });
+
+      afterEach(() => {
+        delete process.env.NAVI_TEST_TOKEN;
+      });
+
+      it('resolves the variable from process.env', () => {
+        expect(EnvResolver.resolveValue('Bearer ${NAVI_TEST_TOKEN}'))
+          .toEqual('Bearer secret-token-value');
+      });
+    });
+
+    describe('when value is only a variable reference', () => {
+      beforeEach(() => {
+        process.env.NAVI_TEST_TOKEN = 'secret-token-value';
+      });
+
+      afterEach(() => {
+        delete process.env.NAVI_TEST_TOKEN;
+      });
+
+      it('resolves to the variable value', () => {
+        expect(EnvResolver.resolveValue('$NAVI_TEST_TOKEN'))
+          .toEqual('secret-token-value');
+      });
+    });
+
+    describe('when the referenced env var is not set', () => {
+      it('replaces the reference with an empty string and logs a warning', () => {
+        spyOn(Logger, 'warn').and.stub();
+
+        expect(EnvResolver.resolveValue('Bearer $NAVI_UNDEFINED_VAR'))
+          .toEqual('Bearer ');
+        expect(Logger.warn).toHaveBeenCalledWith(
+          'Environment variable not defined: NAVI_UNDEFINED_VAR'
+        );
+      });
+    });
+
+    describe('when value is a number', () => {
+      it('coerces it to a string', () => {
+        expect(EnvResolver.resolveValue(42)).toEqual('42');
+      });
+    });
+
+    describe('when value is a boolean', () => {
+      it('coerces it to a string', () => {
+        expect(EnvResolver.resolveValue(true)).toEqual('true');
+      });
+    });
+  });
+
+  describe('.resolveObject', () => {
+    describe('when object has static values', () => {
+      it('returns values unchanged', () => {
+        const input = { 'X-Api-Key': 'abc123', 'Accept': 'application/json' };
+
+        expect(EnvResolver.resolveObject(input)).toEqual(input);
+      });
+    });
+
+    describe('when object has env var references', () => {
+      beforeEach(() => {
+        process.env.NAVI_TEST_TOKEN = 'resolved-value';
+      });
+
+      afterEach(() => {
+        delete process.env.NAVI_TEST_TOKEN;
+      });
+
+      it('resolves env vars in all values', () => {
+        const input = {
+          Authorization: 'Bearer $NAVI_TEST_TOKEN',
+          'X-Static': 'unchanged',
+        };
+
+        expect(EnvResolver.resolveObject(input)).toEqual({
+          Authorization: 'Bearer resolved-value',
+          'X-Static': 'unchanged',
+        });
+      });
+    });
+
+    describe('when object is empty', () => {
+      it('returns an empty object', () => {
+        expect(EnvResolver.resolveObject({})).toEqual({});
+      });
+    });
+  });
+});

--- a/source/spec/support/factories/ClientFactory.js
+++ b/source/spec/support/factories/ClientFactory.js
@@ -10,10 +10,11 @@ class ClientFactory {
    * @param {string} [params.name='default'] - The client name.
    * @param {string} [params.baseUrl='https://example.com'] - The base URL.
    * @param {number} [params.timeout] - Optional request timeout in milliseconds.
+   * @param {object} [params.headers] - Optional HTTP headers.
    * @returns {Client} A new Client instance.
    */
-  static build({ name = 'default', baseUrl = 'https://example.com', timeout } = {}) {
-    return new Client({ name, baseUrl, timeout });
+  static build({ name = 'default', baseUrl = 'https://example.com', timeout, headers } = {}) {
+    return new Client({ name, baseUrl, timeout, headers });
   }
 }
 

--- a/source/spec/support/fixtures/config/sample_config_with_headers.yml
+++ b/source/spec/support/fixtures/config/sample_config_with_headers.yml
@@ -1,0 +1,15 @@
+workers:
+  quantity: 5
+clients:
+  default:
+    base_url: https://example.com
+    timeout: 5000
+  auth_api:
+    base_url: https://api.example.com
+    headers:
+      Authorization: Bearer my-token
+      X-Custom-Header: custom-value
+resources:
+  categories:
+    - url: /categories.json
+      status: 200


### PR DESCRIPTION
## Summary

Implements issue #195: Client configuration now supports `headers` as documented in README, with environment variable interpolation for runtime flexibility.

## Changes

### Client (`source/lib/services/Client.js`)
- Added `headers` field to constructor (default: `{}`)
- Updated `fromObject()` to parse `headers` from config with env var interpolation via `EnvResolver`
- Headers are forwarded to every Axios request via the `headers` option

### EnvResolver (`source/lib/utils/EnvResolver.js`) — New
- Extracted env var resolution logic into a reusable utility class
- `resolveObject(object)` resolves env var references in all values of an object
- `resolveValue(value)` resolves `$VAR` and `${VAR}` references in a single string value
- Non-string values are coerced to strings before resolution
- Missing env vars produce a warning log and resolve to empty string
- Regex pattern extracted to a module-level `ENV_VAR_PATTERN` constant

### Tests
- Updated Client, Worker, and ResourceRequestJob specs to include `headers: {}` in expected Axios calls
- Added `EnvResolver_spec.js` with 10 specs covering: static values, `$VAR` syntax, `${VAR}` syntax, standalone variable reference, undefined var warning, number coercion, boolean coercion, object with mixed values, object with env vars, and empty object
- Added Client integration tests for headers (provided, not provided, env var resolution via `fromObject`)
- Added ConfigParser tests for clients with/without headers
- Added `sample_config_with_headers.yml` fixture

### Documentation
- Updated README YAML example with env var header syntax (`$API_TOKEN`) and expanded field description
- Updated `docs/agents/architecture.md` with Client headers capability and `EnvResolver` entry
- Updated `docs/agents/flow.md` with headers + env var interpolation mention

## Test Results
- 536 specs, 0 failures
- 0 new lint errors (all warnings pre-existing)
- 0 CodeQL security alerts