### PR TITLE
feat: Refactor frontend views to extract Jobs/Workers status into a shared header component

### DIFF
--- a/frontend/spec/components/Layout_spec.js
+++ b/frontend/spec/components/Layout_spec.js
@@ -1,0 +1,94 @@
+import { createElement } from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Layout from '../../src/components/Layout.jsx';
+
+const flushAsync = () => act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+
+const renderLayout = async (root, { children = null } = {}) => {
+  await act(async () => {
+    root.render(
+      createElement(MemoryRouter, null,
+        createElement(Routes, null,
+          createElement(Route, { path: '/', element: createElement(Layout) },
+            children ? createElement(Route, { index: true, element: children }) : null
+          )
+        )
+      )
+    );
+  });
+};
+
+describe('Layout', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  describe('always', () => {
+    beforeEach(async () => {
+      spyOn(globalThis, 'fetch').and.returnValue(new Promise(() => {}));
+      await renderLayout(root);
+    });
+
+    it('renders the Navi title', () => {
+      expect(container.textContent).toContain('Navi — Cache Warmer');
+    });
+
+    it('renders an h1 heading', () => {
+      const h1 = container.querySelector('h1');
+      expect(h1).not.toBeNull();
+      expect(h1.textContent).toContain('Navi — Cache Warmer');
+    });
+  });
+
+  describe('when stats load successfully', () => {
+    const stats = {
+      workers: { idle: 2, busy: 0 },
+      jobs: { enqueued: 1, processing: 0, failed: 0, finished: 5, dead: 0 },
+    };
+
+    beforeEach(async () => {
+      spyOn(globalThis, 'fetch').and.returnValue(
+        Promise.resolve({ ok: true, json: () => Promise.resolve(stats) })
+      );
+      await renderLayout(root);
+      await flushAsync();
+    });
+
+    it('renders the Workers section in the header', () => {
+      expect(container.textContent).toContain('Workers');
+    });
+
+    it('renders the Jobs section in the header', () => {
+      expect(container.textContent).toContain('Jobs');
+    });
+  });
+
+  describe('with page-specific content', () => {
+    beforeEach(async () => {
+      spyOn(globalThis, 'fetch').and.returnValue(new Promise(() => {}));
+      const pageContent = createElement('div', { className: 'page-content' }, 'Page Content');
+      await renderLayout(root, { children: pageContent });
+    });
+
+    it('renders the outlet content', () => {
+      expect(container.textContent).toContain('Page Content');
+    });
+
+    it('renders the title alongside the page content', () => {
+      expect(container.textContent).toContain('Navi — Cache Warmer');
+      expect(container.textContent).toContain('Page Content');
+    });
+  });
+});

--- a/frontend/spec/components/StatsHeader_spec.js
+++ b/frontend/spec/components/StatsHeader_spec.js
@@ -2,15 +2,15 @@ import { createElement } from 'react';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { MemoryRouter } from 'react-router-dom';
-import App from '../src/App.jsx';
+import StatsHeader from '../../src/components/StatsHeader.jsx';
 
 const flushAsync = () => act(async () => { await new Promise((r) => setTimeout(r, 0)); });
 
-const renderApp = (root) => {
-  root.render(createElement(MemoryRouter, null, createElement(App)));
+const renderStatsHeader = (root) => {
+  root.render(createElement(MemoryRouter, null, createElement(StatsHeader)));
 };
 
-describe('App', () => {
+describe('StatsHeader', () => {
   let container;
   let root;
 
@@ -29,7 +29,7 @@ describe('App', () => {
       spyOn(globalThis, 'fetch').and.returnValue(new Promise(() => {}));
       await act(async () => {
         root = createRoot(container);
-        renderApp(root);
+        renderStatsHeader(root);
       });
     });
 
@@ -54,7 +54,7 @@ describe('App', () => {
       );
       await act(async () => {
         root = createRoot(container);
-        renderApp(root);
+        renderStatsHeader(root);
       });
       await flushAsync();
     });
@@ -112,7 +112,7 @@ describe('App', () => {
       );
       await act(async () => {
         root = createRoot(container);
-        renderApp(root);
+        renderStatsHeader(root);
       });
       await flushAsync();
     });

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+import StatsHeader from './StatsHeader.jsx';
+
+function Layout() {
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Navi — Cache Warmer</h1>
+      <StatsHeader />
+      <Outlet />
+    </div>
+  );
+}
+
+export default Layout;

--- a/frontend/src/components/StatsHeader.jsx
+++ b/frontend/src/components/StatsHeader.jsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import fetchStats from './clients/StatsClient.js';
-import JobStatItem from './components/JobStatItem.jsx';
-import StatItem from './components/StatItem.jsx';
+import JobStatItem from './JobStatItem.jsx';
+import StatItem from './StatItem.jsx';
+import fetchStats from '../clients/StatsClient.js';
 
-function App() {
+function StatsHeader() {
   const [stats, setStats] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -27,7 +26,7 @@ function App() {
 
   if (loading) {
     return (
-      <div className="container mt-5 text-center">
+      <div className="text-center my-3">
         <div className="spinner-border" role="status" />
         <p className="mt-2">Loading stats…</p>
       </div>
@@ -36,9 +35,7 @@ function App() {
 
   if (error) {
     return (
-      <div className="container mt-5">
-        <div className="alert alert-danger">Failed to load stats: {error}</div>
-      </div>
+      <div className="alert alert-danger my-3">Failed to load stats: {error}</div>
     );
   }
 
@@ -46,10 +43,8 @@ function App() {
   const jobs = stats.jobs;
 
   return (
-    <div className="container mt-4">
-      <h1 className="mb-4">Navi — Cache Warmer</h1>
-
-      <section className="mb-5">
+    <>
+      <section className="mb-4">
         <h2 className="h4 mb-3">Workers</h2>
         <div className="row row-cols-2 row-cols-md-4 g-3">
           <StatItem label="Idle" value={workers.idle} variant="success" />
@@ -57,7 +52,7 @@ function App() {
         </div>
       </section>
 
-      <section>
+      <section className="mb-4">
         <h2 className="h4 mb-3">Jobs</h2>
         <div className="row row-cols-2 row-cols-md-5 g-3">
           <JobStatItem label="Enqueued" value={jobs.enqueued} variant="secondary" status="enqueued" />
@@ -67,8 +62,8 @@ function App() {
           <JobStatItem label="Dead" value={jobs.dead} variant="dark" status="dead" />
         </div>
       </section>
-    </div>
+    </>
   );
 }
 
-export default App;
+export default StatsHeader;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,18 +1,21 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { HashRouter, Routes, Route } from 'react-router-dom';
-import App from './App.jsx';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import Job from './components/Job.jsx';
 import Jobs from './components/Jobs.jsx';
+import Layout from './components/Layout.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <HashRouter>
       <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="/jobs" element={<Jobs />} />
-        <Route path="/jobs/:status" element={<Jobs />} />
-        <Route path="/job/:id" element={<Job />} />
+        <Route path="/" element={<Layout />}>
+          <Route index element={null} />
+          <Route path="jobs" element={<Jobs />} />
+          <Route path="jobs/:status" element={<Jobs />} />
+          <Route path="job/:id" element={<Job />} />
+        </Route>
       </Routes>
     </HashRouter>
   </StrictMode>,


### PR DESCRIPTION
Closes #380

## Summary

Refactors the frontend to move the Jobs/Workers status section out of the index page and into a shared header component used by all views.

## Changes

### New components
- **`src/components/StatsHeader.jsx`** – Reusable component that fetches and displays the Workers/Jobs statistics (loading/error states included). Previously this logic lived in `App.jsx` as the index page content.
- **`src/components/Layout.jsx`** – Shared layout component that renders:
  - `<h1>Navi — Cache Warmer</h1>` (stars header)
  - `<StatsHeader />` (Jobs/Workers status header)
  - `<Outlet />` (page-specific content slot)

### Modified files
- **`src/main.jsx`** – Converted routing to use `Layout` as a parent route wrapping all child routes (`/`, `/jobs`, `/jobs/:status`, `/job/:id`). Moved bootstrap CSS import here.
- **`src/App.jsx`** – Removed (no longer needed now that Layout handles the base template).

### Tests
- **`spec/components/StatsHeader_spec.js`** – Full test coverage for `StatsHeader` (loading spinner, successful stats, fetch error, link targets).
- **`spec/components/Layout_spec.js`** – Tests that Layout renders the title, the stats header, and renders outlet content.
- **`spec/App_spec.js`** – Removed (App component removed).

## Result

- 88 specs, 0 failures
- Lint: clean