### PR TITLE
Preserve query string on dev/app redirects

### DIFF
--- a/dev/app/.gitignore
+++ b/dev/app/.gitignore
@@ -1,2 +1,4 @@
 lib/common/
 spec/lib/common/
+coverage/
+report/

--- a/dev/app/lib/handlers/RedirectHandler.js
+++ b/dev/app/lib/handlers/RedirectHandler.js
@@ -1,5 +1,5 @@
+import RedirectHandlerExecutor from './RedirectHandlerExecutor.js';
 import RequestHandler from './RequestHandler.js';
-import RedirectLocation from '../models/RedirectLocation.js';
 
 /**
  * Handles an incoming Express request by issuing an HTTP 302 redirect to
@@ -21,13 +21,12 @@ class RedirectHandler extends RequestHandler {
   }
 
   /**
-   * Builds the redirect location and responds with 302.
+   * Delegates redirect processing to RedirectHandlerExecutor.
    * @param {import('express').Request} req
    * @param {import('express').Response} res
    */
   handle(req, res) {
-    const location = new RedirectLocation(this.#target, req.params).build();
-    res.redirect(302, location);
+    new RedirectHandlerExecutor(req, res, this.#target).handle();
   }
 }
 

--- a/dev/app/lib/handlers/RedirectHandlerExecutor.js
+++ b/dev/app/lib/handlers/RedirectHandlerExecutor.js
@@ -1,0 +1,62 @@
+import RedirectLocation from '../models/RedirectLocation.js';
+import RedirectQueryString from '../models/RedirectQueryString.js';
+
+/**
+ * Executes request-handling behavior for redirect routes.
+ */
+class RedirectHandlerExecutor {
+  #request;
+  #response;
+  #target;
+  // Only allow relative hash-routes and RFC3986-safe query characters.
+  // This guarantees redirects stay inside the SPA (`/#/...`) and never become absolute URLs.
+  #safeRedirectPattern = /^\/#\/[A-Za-z0-9/_-]*(\?[A-Za-z0-9\-._~%!$&'()*+,;=:/?]*)?$/;
+
+  /**
+   * @param {import('express').Request} request
+   * @param {import('express').Response} response
+   * @param {string} target
+   */
+  constructor(request, response, target) {
+    this.#request = request;
+    this.#response = response;
+    this.#target = target;
+  }
+
+  /**
+   * Executes the redirect flow and writes the response.
+   */
+  handle() {
+    this.#response.redirect(302, this.#buildSafeRedirectLocation());
+  }
+
+  /**
+   * Builds the redirect destination including route params and query string.
+   * @returns {string}
+   */
+  #buildRedirectLocation() {
+    const location = new RedirectLocation(this.#target, this.#request.params).build();
+    const queryString = new RedirectQueryString(this.#request.query).build();
+    return queryString === '' ? location : `${location}?${queryString}`;
+  }
+
+  /**
+   * Builds the final safe redirect destination.
+   * @returns {string}
+   */
+  #buildSafeRedirectLocation() {
+    const redirectLocation = this.#buildRedirectLocation();
+    return this.#isSafeRedirectLocation(redirectLocation) ? redirectLocation : '/#/';
+  }
+
+  /**
+   * Checks whether the resolved redirect destination is a safe relative hash route.
+   * @param {string} location
+   * @returns {boolean}
+   */
+  #isSafeRedirectLocation(location) {
+    return this.#safeRedirectPattern.test(location);
+  }
+}
+
+export default RedirectHandlerExecutor;

--- a/dev/app/lib/models/RedirectQueryString.js
+++ b/dev/app/lib/models/RedirectQueryString.js
@@ -1,0 +1,72 @@
+/**
+ * Builds a sanitized query string for redirect URLs.
+ */
+class RedirectQueryString {
+  #query;
+  // Reject protocol-relative (`//host`) and absolute (`scheme://host`) URL-like values
+  // so query params cannot smuggle external redirect targets.
+  #unsafeQueryValuePattern = /^(\/\/|[a-z][a-z0-9+.-]*:\/\/)/i;
+
+  /**
+   * @param {Object<string, string|string[]|undefined>} query
+   */
+  constructor(query) {
+    this.#query = query;
+  }
+
+  /**
+   * Builds a normalized query string while rejecting URL-like values.
+   * @returns {string}
+   */
+  build() {
+    const queryParams = new URLSearchParams();
+
+    Object.entries(this.#query).forEach(([key, value]) => {
+      this.#appendQueryValue(queryParams, key, value);
+    });
+
+    return queryParams.toString();
+  }
+
+  /**
+   * Appends query value(s) into query params, filtering unsafe values.
+   * @param {URLSearchParams} queryParams
+   * @param {string} key
+   * @param {string|string[]|undefined} value
+   */
+  #appendQueryValue(queryParams, key, value) {
+    if (Array.isArray(value)) {
+      this.#appendArrayQueryValue(queryParams, key, value);
+      return;
+    }
+
+    if (value !== undefined && !this.#isUnsafeQueryValue(value)) {
+      queryParams.append(key, value);
+    }
+  }
+
+  /**
+   * Appends array query values into query params, filtering unsafe values.
+   * @param {URLSearchParams} queryParams
+   * @param {string} key
+   * @param {string[]} values
+   */
+  #appendArrayQueryValue(queryParams, key, values) {
+    values.forEach((item) => {
+      if (!this.#isUnsafeQueryValue(item)) {
+        queryParams.append(key, item);
+      }
+    });
+  }
+
+  /**
+   * Checks whether a query value looks like a URL or protocol-relative URL.
+   * @param {unknown} value
+   * @returns {boolean}
+   */
+  #isUnsafeQueryValue(value) {
+    return this.#unsafeQueryValuePattern.test(`${value}`);
+  }
+}
+
+export default RedirectQueryString;

--- a/dev/app/spec/lib/handlers/RedirectHandlerExecutor_spec.js
+++ b/dev/app/spec/lib/handlers/RedirectHandlerExecutor_spec.js
@@ -1,0 +1,38 @@
+import RedirectHandlerExecutor from '../../../lib/handlers/RedirectHandlerExecutor.js';
+
+describe('RedirectHandlerExecutor', () => {
+  const execute = ({ target, params = {}, query = {} }) => {
+    const request = { params, query };
+    const response = { redirect: jasmine.createSpy('redirect') };
+    new RedirectHandlerExecutor(request, response, target).handle();
+    return response.redirect.calls.mostRecent().args;
+  };
+
+  it('builds redirect location with params and query string', () => {
+    const result = execute({
+      target: '/#/categories/:id',
+      params: { id: '3' },
+      query: { search: 'hobbit', order: 'asc' }
+    });
+
+    expect(result).toEqual([302, '/#/categories/3?search=hobbit&order=asc']);
+  });
+
+  it('filters URL-like query values', () => {
+    const result = execute({
+      target: '/#/categories',
+      query: { redirect: '//evil.com', search: 'hobbit' }
+    });
+
+    expect(result).toEqual([302, '/#/categories?search=hobbit']);
+  });
+
+  it('falls back to /#/ when redirect destination is unsafe', () => {
+    const result = execute({
+      target: 'http://example.com/:id',
+      params: { id: '7' }
+    });
+
+    expect(result).toEqual([302, '/#/']);
+  });
+});

--- a/dev/app/spec/lib/handlers/RedirectHandler_spec.js
+++ b/dev/app/spec/lib/handlers/RedirectHandler_spec.js
@@ -22,6 +22,23 @@ describe('RedirectHandler', () => {
       const res = await request(app).get('/categories').redirects(0);
       expect(res.headers['location']).toBe('/#/categories');
     });
+
+    it('preserves query string in Location header', async () => {
+      const res = await request(app).get('/categories?search=hobbit&order=asc').redirects(0);
+      expect(res.headers['location']).toBe('/#/categories?search=hobbit&order=asc');
+    });
+
+    it('preserves repeated query parameters in Location header', async () => {
+      const res = await request(app).get('/categories?tag=books&tag=fantasy').redirects(0);
+      expect(res.headers['location']).toBe('/#/categories?tag=books&tag=fantasy');
+    });
+
+    it('drops query params that look like external URLs', async () => {
+      const res = await request(app)
+        .get('/categories?redirect=//evil.com&search=hobbit')
+        .redirects(0);
+      expect(res.headers['location']).toBe('/#/categories?search=hobbit');
+    });
   });
 
   describe('#handle — route with one param', () => {
@@ -52,6 +69,15 @@ describe('RedirectHandler', () => {
     it('substitutes both params into the Location header', async () => {
       const res = await request(app).get('/categories/3/items/7').redirects(0);
       expect(res.headers['location']).toBe('/#/categories/3/items/7');
+    });
+  });
+
+  describe('#handle — unsafe redirect destination', () => {
+    const app = buildApp('/categories/:id', 'http://example.com/:id');
+
+    it('falls back to /#/ when destination is not a safe relative hash route', async () => {
+      const res = await request(app).get('/categories/3').redirects(0);
+      expect(res.headers['location']).toBe('/#/');
     });
   });
 });

--- a/dev/app/spec/lib/models/RedirectQueryString_spec.js
+++ b/dev/app/spec/lib/models/RedirectQueryString_spec.js
@@ -1,0 +1,35 @@
+import RedirectQueryString from '../../../lib/models/RedirectQueryString.js';
+
+describe('RedirectQueryString', () => {
+  describe('#build — with regular params', () => {
+    it('builds the expected query string', () => {
+      const query = new RedirectQueryString({ search: 'hobbit', order: 'asc' }).build();
+      expect(query).toBe('search=hobbit&order=asc');
+    });
+  });
+
+  describe('#build — with repeated params', () => {
+    it('preserves repeated values', () => {
+      const query = new RedirectQueryString({ tag: ['books', 'fantasy'] }).build();
+      expect(query).toBe('tag=books&tag=fantasy');
+    });
+  });
+
+  describe('#build — with URL-like values', () => {
+    it('filters protocol-relative values', () => {
+      const query = new RedirectQueryString({
+        redirect: '//evil.com',
+        search: 'hobbit'
+      }).build();
+      expect(query).toBe('search=hobbit');
+    });
+
+    it('filters absolute URL values', () => {
+      const query = new RedirectQueryString({
+        redirect: 'https://evil.com',
+        search: 'hobbit'
+      }).build();
+      expect(query).toBe('search=hobbit');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- preserve query strings for hash redirects in `dev/app` category routes (`/?` -> `/#/?` pattern)
- keep `.json` API routes unchanged
- harden redirect handling by validating safe hash-relative destinations and filtering URL-like unsafe query values
- add redirect handler test coverage for query preservation (including repeated params) and unsafe destination fallback
- ignore generated `dev/app/coverage` and `dev/app/report` artifacts to avoid accidental commits

## Validation
- `cd /home/runner/work/navi/navi && rm -rf dev/app/lib/common dev/app/spec/lib/common && cp -r source/lib/common dev/app/lib/common && cp -r source/spec/lib/common dev/app/spec/lib/common && cd dev/app && yarn coverage`
- `cd /home/runner/work/navi/navi/dev/app && yarn lint`
- `cd /home/runner/work/navi/navi/dev/app && yarn report`

## Notes
- `parallel_validation` ran successfully earlier in this session (CodeQL reached zero alerts after fixes).
- A final rerun could not be executed because the validation time budget was exhausted (`Validation budget exhausted`).

Closes #562