### PR TITLE
Extract reusable React element components from helpers/pages

### DIFF
--- a/frontend/spec/components/JobRow_spec.js
+++ b/frontend/spec/components/JobRow_spec.js
@@ -1,0 +1,54 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import JobRow from '../../src/components/elements/JobRow.jsx';
+
+const render = (job) => renderToStaticMarkup(
+  createElement(MemoryRouter, null, createElement(JobRow, { job }))
+);
+
+describe('JobRow', () => {
+  const job = {
+    id: 'abc123',
+    status: 'enqueued',
+    attempts: 2,
+    jobClass: 'ResourceRequestJob',
+    url: 'https://example.com',
+  };
+
+  it('renders a table row', () => {
+    expect(render(job)).toContain('<tr');
+  });
+
+  it('renders the job id as a link', () => {
+    const html = render(job);
+    expect(html).toContain('abc123');
+    expect(html).toContain('href="/job/abc123"');
+  });
+
+  it('renders the job status badge', () => {
+    expect(render(job)).toContain('enqueued');
+    expect(render(job)).toContain('badge');
+    expect(render(job)).toContain('text-bg-secondary');
+  });
+
+  it('renders the attempts count', () => {
+    expect(render(job)).toContain('2');
+  });
+
+  it('renders the job class', () => {
+    expect(render(job)).toContain('ResourceRequestJob');
+  });
+
+  it('renders the url', () => {
+    expect(render(job)).toContain('https://example.com');
+  });
+
+  describe('when url is absent', () => {
+    const jobWithoutUrl = { ...job, url: null };
+
+    it('renders an em dash', () => {
+      expect(render(jobWithoutUrl)).toContain('—');
+    });
+  });
+});

--- a/frontend/spec/components/JobStatusBadge_spec.js
+++ b/frontend/spec/components/JobStatusBadge_spec.js
@@ -1,0 +1,39 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import JobStatusBadge from '../../src/components/elements/JobStatusBadge.jsx';
+
+const render = (status) => renderToStaticMarkup(createElement(JobStatusBadge, { status }));
+
+describe('JobStatusBadge', () => {
+  it('renders a badge with the status text', () => {
+    expect(render('enqueued')).toContain('enqueued');
+  });
+
+  it('applies the correct variant class for enqueued', () => {
+    expect(render('enqueued')).toContain('text-bg-secondary');
+  });
+
+  it('applies the correct variant class for processing', () => {
+    expect(render('processing')).toContain('text-bg-primary');
+  });
+
+  it('applies the correct variant class for failed', () => {
+    expect(render('failed')).toContain('text-bg-danger');
+  });
+
+  it('applies the correct variant class for finished', () => {
+    expect(render('finished')).toContain('text-bg-success');
+  });
+
+  it('applies the correct variant class for dead', () => {
+    expect(render('dead')).toContain('text-bg-dark');
+  });
+
+  it('falls back to secondary for an unknown status', () => {
+    expect(render('unknown')).toContain('text-bg-secondary');
+  });
+
+  it('renders a badge element', () => {
+    expect(render('enqueued')).toContain('badge');
+  });
+});

--- a/frontend/spec/components/JobsTable_spec.js
+++ b/frontend/spec/components/JobsTable_spec.js
@@ -1,0 +1,50 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import JobsTable from '../../src/components/elements/JobsTable.jsx';
+
+const render = (jobs) => renderToStaticMarkup(
+  createElement(MemoryRouter, null, createElement(JobsTable, { jobs }))
+);
+
+describe('JobsTable', () => {
+  describe('with jobs', () => {
+    const jobs = [
+      { id: 'abc', status: 'enqueued', attempts: 0, jobClass: 'ResourceRequestJob', url: null },
+      { id: 'def', status: 'failed', attempts: 3, jobClass: 'HtmlParseJob', url: 'https://example.com' },
+    ];
+
+    it('renders a table', () => {
+      expect(render(jobs)).toContain('<table');
+    });
+
+    it('renders table headers', () => {
+      const html = render(jobs);
+      expect(html).toContain('ID');
+      expect(html).toContain('Status');
+      expect(html).toContain('Attempts');
+      expect(html).toContain('Class');
+      expect(html).toContain('URL');
+    });
+
+    it('renders a row for each job', () => {
+      const html = render(jobs);
+      expect(html).toContain('abc');
+      expect(html).toContain('def');
+    });
+
+    it('does not show the empty state message', () => {
+      expect(render(jobs)).not.toContain('No jobs found');
+    });
+  });
+
+  describe('with no jobs', () => {
+    it('does not render a table', () => {
+      expect(render([])).not.toContain('<table');
+    });
+
+    it('shows the empty state message', () => {
+      expect(render([])).toContain('No jobs found');
+    });
+  });
+});

--- a/frontend/spec/components/LinksDropdownItem_spec.js
+++ b/frontend/spec/components/LinksDropdownItem_spec.js
@@ -1,0 +1,31 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import LinksDropdownItem from '../../src/components/elements/LinksDropdownItem.jsx';
+
+const render = (props) => renderToStaticMarkup(createElement(LinksDropdownItem, props));
+
+describe('LinksDropdownItem', () => {
+  it('renders a list item', () => {
+    expect(render({ text: 'Home', url: 'https://example.com' })).toContain('<li');
+  });
+
+  it('renders the link text', () => {
+    expect(render({ text: 'Home', url: 'https://example.com' })).toContain('Home');
+  });
+
+  it('renders the link href', () => {
+    expect(render({ text: 'Home', url: 'https://example.com' })).toContain('href="https://example.com"');
+  });
+
+  it('opens in a new tab', () => {
+    expect(render({ text: 'Home', url: 'https://example.com' })).toContain('target="_blank"');
+  });
+
+  it('applies the dropdown-item class', () => {
+    expect(render({ text: 'Home', url: 'https://example.com' })).toContain('dropdown-item');
+  });
+
+  it('applies rel noreferrer', () => {
+    expect(render({ text: 'Home', url: 'https://example.com' })).toContain('rel="noreferrer"');
+  });
+});

--- a/frontend/spec/components/LinksDropdown_spec.js
+++ b/frontend/spec/components/LinksDropdown_spec.js
@@ -1,0 +1,76 @@
+import { createElement } from 'react';
+import { act } from 'react';
+import LinksDropdown from '../../src/components/elements/LinksDropdown.jsx';
+import { useContainer } from '../support/dom.js';
+
+const links = [
+  { text: 'Home', url: 'https://example.com' },
+  { text: 'Docs', url: 'https://example.com/docs' },
+];
+
+describe('LinksDropdown', () => {
+  const state = useContainer();
+
+  const render = async (open) => {
+    const setOpen = jasmine.createSpy('setOpen');
+    const containerRef = { current: null };
+    await act(async () => {
+      state.root.render(
+        createElement(LinksDropdown, { containerRef, open, setOpen, links })
+      );
+    });
+    return setOpen;
+  };
+
+  describe('when closed', () => {
+    beforeEach(async () => { await render(false); });
+
+    it('renders the toggle button', () => {
+      expect(state.container.querySelector('button')).not.toBeNull();
+    });
+
+    it('shows "Links" on the button', () => {
+      expect(state.container.querySelector('button').textContent).toContain('Links');
+    });
+
+    it('does not show any links', () => {
+      expect(state.container.querySelectorAll('a').length).toBe(0);
+    });
+
+    it('sets aria-expanded to false', () => {
+      expect(state.container.querySelector('button').getAttribute('aria-expanded')).toBe('false');
+    });
+  });
+
+  describe('when open', () => {
+    beforeEach(async () => { await render(true); });
+
+    it('shows all link items', () => {
+      expect(state.container.querySelectorAll('a').length).toBe(2);
+    });
+
+    it('shows the link text', () => {
+      expect(state.container.textContent).toContain('Home');
+      expect(state.container.textContent).toContain('Docs');
+    });
+
+    it('sets aria-expanded to true', () => {
+      expect(state.container.querySelector('button').getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
+  describe('when the toggle button is clicked', () => {
+    let setOpen;
+
+    beforeEach(async () => {
+      setOpen = await render(false);
+      await act(async () => {
+        state.container.querySelector('button').click();
+      });
+    });
+
+    it('calls setOpen', () => {
+      expect(setOpen).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/spec/components/LogEntry_spec.js
+++ b/frontend/spec/components/LogEntry_spec.js
@@ -1,0 +1,45 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import LogEntry from '../../src/components/elements/LogEntry.jsx';
+
+const render = (log) => renderToStaticMarkup(createElement(LogEntry, { log }));
+
+describe('LogEntry', () => {
+  it('renders the log message', () => {
+    const log = { id: 1, level: 'info', message: 'Server started', timestamp: '2024-01-01T00:00:00Z' };
+    expect(render(log)).toContain('Server started');
+  });
+
+  it('renders the timestamp in brackets', () => {
+    const log = { id: 1, level: 'info', message: 'Server started', timestamp: '2024-01-01T00:00:00Z' };
+    expect(render(log)).toContain('[2024-01-01T00:00:00Z]');
+  });
+
+  it('renders the level in brackets', () => {
+    const log = { id: 1, level: 'warn', message: 'High memory', timestamp: '2024-01-01T00:00:00Z' };
+    expect(render(log)).toContain('[warn]');
+  });
+
+  it('applies text-warning class for warn level', () => {
+    const log = { id: 1, level: 'warn', message: 'High memory', timestamp: '2024-01-01T00:00:00Z' };
+    expect(render(log)).toContain('text-warning');
+  });
+
+  it('applies text-danger class for error level', () => {
+    const log = { id: 1, level: 'error', message: 'Crash', timestamp: '2024-01-01T00:00:00Z' };
+    expect(render(log)).toContain('text-danger');
+  });
+
+  it('applies text-debug class for debug level', () => {
+    const log = { id: 1, level: 'debug', message: 'Cache hit', timestamp: '2024-01-01T00:00:00Z' };
+    expect(render(log)).toContain('text-debug');
+  });
+
+  it('does not apply a colour class for info level', () => {
+    const log = { id: 1, level: 'info', message: 'All good', timestamp: '2024-01-01T00:00:00Z' };
+    const html = render(log);
+    expect(html).not.toContain('text-warning');
+    expect(html).not.toContain('text-danger');
+    expect(html).not.toContain('text-debug');
+  });
+});

--- a/frontend/spec/components/LogsPanel_spec.js
+++ b/frontend/spec/components/LogsPanel_spec.js
@@ -1,0 +1,84 @@
+import { createElement } from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import LogsPanel from '../../src/components/elements/LogsPanel.jsx';
+
+describe('LogsPanel', () => {
+  let container;
+  let root;
+  const bottomRef = { current: null };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    document.body.removeChild(container);
+  });
+
+  describe('with no logs', () => {
+    beforeEach(async () => {
+      await act(async () => {
+        root.render(createElement(LogsPanel, { logs: [], bottomRef }));
+      });
+    });
+
+    it('renders the terminal container', () => {
+      expect(container.querySelector('.bg-dark')).not.toBeNull();
+    });
+
+    it('applies text-light class', () => {
+      expect(container.querySelector('.bg-dark.text-light')).not.toBeNull();
+    });
+
+    it('renders no log entries', () => {
+      const rows = Array.from(container.querySelectorAll('.bg-dark > div'))
+        .filter((el) => el.textContent.trim() !== '');
+      expect(rows.length).toBe(0);
+    });
+  });
+
+  describe('with log entries', () => {
+    const logs = [
+      { id: 1, level: 'info', message: 'Started', timestamp: '2024-01-01T00:00:00Z' },
+      { id: 2, level: 'warn', message: 'Warning', timestamp: '2024-01-01T00:00:01Z' },
+      { id: 3, level: 'error', message: 'Failed', timestamp: '2024-01-01T00:00:02Z' },
+      { id: 4, level: 'debug', message: 'Trace', timestamp: '2024-01-01T00:00:03Z' },
+    ];
+
+    beforeEach(async () => {
+      await act(async () => {
+        root.render(createElement(LogsPanel, { logs, bottomRef }));
+      });
+    });
+
+    it('renders a row for each log entry', () => {
+      const rows = container.querySelectorAll('.bg-dark > div');
+      expect(rows.length).toBe(logs.length + 1); // +1 for sentinel div
+    });
+
+    it('shows message text', () => {
+      expect(container.textContent).toContain('Started');
+      expect(container.textContent).toContain('Warning');
+    });
+
+    it('shows timestamps', () => {
+      expect(container.textContent).toContain('[2024-01-01T00:00:00Z]');
+    });
+
+    it('applies text-warning class to warn entries', () => {
+      expect(container.querySelector('.text-warning')).not.toBeNull();
+    });
+
+    it('applies text-danger class to error entries', () => {
+      expect(container.querySelector('.text-danger')).not.toBeNull();
+    });
+
+    it('applies text-debug class to debug entries', () => {
+      expect(container.querySelector('.text-debug')).not.toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/elements/JobRow.jsx
+++ b/frontend/src/components/elements/JobRow.jsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+import JobStatusBadge from './JobStatusBadge.jsx';
+
+function JobRow({ job }) {
+  return (
+    <tr>
+      <td>
+        <Link to={`/job/${job.id}`}>{job.id}</Link>
+      </td>
+      <td>
+        <JobStatusBadge status={job.status} />
+      </td>
+      <td>{job.attempts}</td>
+      <td>{job.jobClass}</td>
+      <td>{job.url ?? '—'}</td>
+    </tr>
+  );
+}
+
+export default JobRow;

--- a/frontend/src/components/elements/JobStatusBadge.jsx
+++ b/frontend/src/components/elements/JobStatusBadge.jsx
@@ -1,0 +1,8 @@
+import { VARIANT_BY_STATUS } from '../../constants/jobStatus.js';
+
+function JobStatusBadge({ status }) {
+  const variant = VARIANT_BY_STATUS[status] ?? 'secondary';
+  return <span className={`badge text-bg-${variant}`}>{status}</span>;
+}
+
+export default JobStatusBadge;

--- a/frontend/src/components/elements/JobsTable.jsx
+++ b/frontend/src/components/elements/JobsTable.jsx
@@ -1,0 +1,16 @@
+import JobsTableHelper from './helpers/JobsTableHelper.jsx';
+
+function JobsTable({ jobs }) {
+  if (jobs.length === 0) {
+    return <p className="text-muted">No jobs found.</p>;
+  }
+
+  return (
+    <table className="table table-striped">
+      {JobsTableHelper.renderHeader()}
+      {JobsTableHelper.renderBody(jobs)}
+    </table>
+  );
+}
+
+export default JobsTable;

--- a/frontend/src/components/elements/LinksDropdown.jsx
+++ b/frontend/src/components/elements/LinksDropdown.jsx
@@ -1,0 +1,18 @@
+import LinksDropdownHelper from './helpers/LinksDropdownHelper.jsx';
+
+function LinksDropdown({ containerRef, open, setOpen, links }) {
+  return (
+    <div ref={containerRef} className="dropdown d-inline-block">
+      <button
+        className="btn btn-sm btn-outline-secondary dropdown-toggle"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+      >
+        Links
+      </button>
+      {open && LinksDropdownHelper.renderLinks(links)}
+    </div>
+  );
+}
+
+export default LinksDropdown;

--- a/frontend/src/components/elements/LinksDropdownItem.jsx
+++ b/frontend/src/components/elements/LinksDropdownItem.jsx
@@ -1,0 +1,11 @@
+function LinksDropdownItem({ text, url }) {
+  return (
+    <li>
+      <a href={url} target="_blank" rel="noreferrer" className="dropdown-item">
+        {text}
+      </a>
+    </li>
+  );
+}
+
+export default LinksDropdownItem;

--- a/frontend/src/components/elements/LogEntry.jsx
+++ b/frontend/src/components/elements/LogEntry.jsx
@@ -1,0 +1,16 @@
+const LEVEL_CLASS = {
+  debug: 'text-debug',
+  info: '',
+  warn: 'text-warning',
+  error: 'text-danger',
+};
+
+function LogEntry({ log }) {
+  return (
+    <div className={LEVEL_CLASS[log.level] ?? ''}>
+      [{log.timestamp}] [{log.level}] {log.message}
+    </div>
+  );
+}
+
+export default LogEntry;

--- a/frontend/src/components/elements/LogsPanel.jsx
+++ b/frontend/src/components/elements/LogsPanel.jsx
@@ -1,0 +1,15 @@
+import LogsPanelHelper from './helpers/LogsPanelHelper.jsx';
+
+function LogsPanel({ logs, bottomRef }) {
+  return (
+    <div
+      className="bg-dark text-light p-3 rounded"
+      style={{ fontFamily: 'monospace', minHeight: '400px', overflowY: 'auto', maxHeight: '80vh' }}
+    >
+      {LogsPanelHelper.renderEntries(logs)}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
+
+export default LogsPanel;

--- a/frontend/src/components/elements/helpers/JobDetailsHelper.jsx
+++ b/frontend/src/components/elements/helpers/JobDetailsHelper.jsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import { VARIANT_BY_STATUS } from '../../../constants/jobStatus.js';
 import CollapsibleSection from '../CollapsibleSection.jsx';
+import JobStatusBadge from '../JobStatusBadge.jsx';
 import LastErrorSection from '../LastErrorSection.jsx';
 import ReadyInRow from '../ReadyInRow.jsx';
 import RemainingAttempts from '../RemainingAttempts.jsx';
@@ -8,8 +8,6 @@ import RetryButton from '../RetryButton.jsx';
 
 class JobDetailsHelper {
   static render(job, onRetry) {
-    const variant = VARIANT_BY_STATUS[job.status] ?? 'secondary';
-
     return (
       <div className="container mt-4">
         <h1 className="mb-4">Job Details</h1>
@@ -21,7 +19,7 @@ class JobDetailsHelper {
 
               <dt className="col-sm-3">Status</dt>
               <dd className="col-sm-9">
-                <span className={`badge text-bg-${variant}`}>{job.status}</span>
+                <JobStatusBadge status={job.status} />
               </dd>
 
               <dt className="col-sm-3">Attempts</dt>

--- a/frontend/src/components/elements/helpers/JobsTableHelper.jsx
+++ b/frontend/src/components/elements/helpers/JobsTableHelper.jsx
@@ -1,0 +1,29 @@
+import JobRow from '../JobRow.jsx';
+
+class JobsTableHelper {
+  static renderHeader() {
+    return (
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Status</th>
+          <th>Attempts</th>
+          <th>Class</th>
+          <th>URL</th>
+        </tr>
+      </thead>
+    );
+  }
+
+  static renderBody(jobs) {
+    return (
+      <tbody>
+        {jobs.map((job) => (
+          <JobRow key={job.id} job={job} />
+        ))}
+      </tbody>
+    );
+  }
+}
+
+export default JobsTableHelper;

--- a/frontend/src/components/elements/helpers/LinksDropdownHelper.jsx
+++ b/frontend/src/components/elements/helpers/LinksDropdownHelper.jsx
@@ -1,0 +1,15 @@
+import LinksDropdownItem from '../LinksDropdownItem.jsx';
+
+class LinksDropdownHelper {
+  static renderLinks(links) {
+    return (
+      <ul className="dropdown-menu show">
+        {links.map(({ text, url }) => (
+          <LinksDropdownItem key={`${text}-${url}`} text={text} url={url} />
+        ))}
+      </ul>
+    );
+  }
+}
+
+export default LinksDropdownHelper;

--- a/frontend/src/components/elements/helpers/LinksMenuHelper.jsx
+++ b/frontend/src/components/elements/helpers/LinksMenuHelper.jsx
@@ -1,3 +1,5 @@
+import LinksDropdown from '../LinksDropdown.jsx';
+
 class LinksMenuHelper {
   #links;
 
@@ -9,32 +11,14 @@ class LinksMenuHelper {
     return this.#links.length > 0;
   }
 
-  renderLinks() {
-    return (
-      <ul className="dropdown-menu show">
-        {this.#links.map(({ text, url }) => (
-          <li key={`${text}-${url}`}>
-            <a href={url} target="_blank" rel="noreferrer" className="dropdown-item">
-              {text}
-            </a>
-          </li>
-        ))}
-      </ul>
-    );
-  }
-
   renderDropdown(containerRef, open, setOpen) {
     return (
-      <div ref={containerRef} className="dropdown d-inline-block">
-        <button
-          className="btn btn-sm btn-outline-secondary dropdown-toggle"
-          onClick={() => setOpen((prev) => !prev)}
-          aria-expanded={open}
-        >
-          Links
-        </button>
-        {open && this.renderLinks()}
-      </div>
+      <LinksDropdown
+        containerRef={containerRef}
+        open={open}
+        setOpen={setOpen}
+        links={this.#links}
+      />
     );
   }
 }

--- a/frontend/src/components/elements/helpers/LogsHelper.jsx
+++ b/frontend/src/components/elements/helpers/LogsHelper.jsx
@@ -1,9 +1,4 @@
-const LEVEL_CLASS = {
-  debug: 'text-debug',
-  info: '',
-  warn: 'text-warning',
-  error: 'text-danger',
-};
+import LogsPanel from '../LogsPanel.jsx';
 
 class LogsHelper {
   #logs;
@@ -17,26 +12,7 @@ class LogsHelper {
   }
 
   render(bottomRef) {
-    return (
-      <div
-        className="bg-dark text-light p-3 rounded"
-        style={{ fontFamily: 'monospace', minHeight: '400px', overflowY: 'auto', maxHeight: '80vh' }}
-      >
-        {this.#logs.map((log) => this.#renderEntry(log))}
-        <div ref={bottomRef} />
-      </div>
-    );
-  }
-
-  #renderEntry(log) {
-    return (
-      <div
-        key={log.id}
-        className={LEVEL_CLASS[log.level] ?? ''}
-      >
-        [{log.timestamp}] [{log.level}] {log.message}
-      </div>
-    );
+    return <LogsPanel logs={this.#logs} bottomRef={bottomRef} />;
   }
 }
 

--- a/frontend/src/components/elements/helpers/LogsPanelHelper.jsx
+++ b/frontend/src/components/elements/helpers/LogsPanelHelper.jsx
@@ -1,0 +1,11 @@
+import LogEntry from '../LogEntry.jsx';
+
+class LogsPanelHelper {
+  static renderEntries(logs) {
+    return logs.map((log) => (
+      <LogEntry key={log.id} log={log} />
+    ));
+  }
+}
+
+export default LogsPanelHelper;

--- a/frontend/src/components/pages/Jobs.jsx
+++ b/frontend/src/components/pages/Jobs.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams, useLocation, useNavigate } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import JobsController from './controllers/JobsController.jsx';
 import JobsHelper from './helpers/JobsHelper.jsx';
-import { VARIANT_BY_STATUS } from '../../constants/jobStatus.js';
+import JobsTable from '../elements/JobsTable.jsx';
 
 function Jobs() {
   const { status } = useParams();
@@ -26,39 +26,7 @@ function Jobs() {
       <h1 className="mb-4">Jobs</h1>
       {JobsHelper.renderStatusTabs(status, filterQuery)}
       {JobsHelper.renderFilterPanel(activeFilters, handleClassFilterChange)}
-      {jobs.length === 0
-        ? <p className="text-muted">No jobs found.</p>
-        : (
-          <table className="table table-striped">
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>Status</th>
-                <th>Attempts</th>
-                <th>Class</th>
-                <th>URL</th>
-              </tr>
-            </thead>
-            <tbody>
-              {jobs.map((job) => (
-                <tr key={job.id}>
-                  <td>
-                    <Link to={`/job/${job.id}`}>{job.id}</Link>
-                  </td>
-                  <td>
-                    <span className={`badge text-bg-${VARIANT_BY_STATUS[job.status] ?? 'secondary'}`}>
-                      {job.status}
-                    </span>
-                  </td>
-                  <td>{job.attempts}</td>
-                  <td>{job.jobClass}</td>
-                  <td>{job.url ?? '—'}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )
-      }
+      <JobsTable jobs={jobs} />
     </div>
   );
 }


### PR DESCRIPTION
Several helpers and pages embedded significant JSX directly, making it hard to reuse UI pieces and keeping rendering logic mixed with orchestration. This PR extracts that markup into focused element components under `elements/`.

## New components

| Component | Source | Renders |
|---|---|---|
| `JobStatusBadge` | `Jobs.jsx`, `JobDetailsHelper` | Bootstrap status badge span |
| `JobRow` | `Jobs.jsx` | Single jobs table row |
| `JobsTable` | `Jobs.jsx` | Full table + empty state |
| `LogEntry` | `LogsHelper` | Single log line with level colouring |
| `LogsPanel` | `LogsHelper` | Monospace log terminal container |
| `LinksDropdownItem` | `LinksMenuHelper` | Individual `<li>` dropdown link |
| `LinksDropdown` | `LinksMenuHelper` | Full dropdown widget |

## New helpers

Rendering logic extracted from the new element components is organised into dedicated helper classes under `elements/helpers/`, following the existing helper pattern:

| Helper | Used by | Methods |
|---|---|---|
| `JobsTableHelper` | `JobsTable` | `renderHeader()`, `renderBody(jobs)` |
| `LinksDropdownHelper` | `LinksDropdown` | `renderLinks(links)` |
| `LogsPanelHelper` | `LogsPanel` | `renderEntries(logs)` |

## Callers simplified

`Jobs.jsx` goes from 25 lines of embedded table markup to:
```jsx
<JobsTable jobs={jobs} />
```

`LogsHelper.render()` and `LinksMenuHelper.renderDropdown()` now delegate entirely to the new components. `JobDetailsHelper` reuses `JobStatusBadge` instead of duplicating the badge expression.

Fixes #592 